### PR TITLE
Collapsed Metric Groups

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,2 +1,3 @@
 //= require jquery
+//= require collapsed_metric_group
 //= require metrics_filter_panel

--- a/app/assets/javascripts/collapsed_metric_group.js
+++ b/app/assets/javascripts/collapsed_metric_group.js
@@ -1,7 +1,28 @@
 (function() {
 
   $.fn.collapsedMetricGroup = function() {
-    $(this).addClass('m-metric-group__collapsed');
+    $(this).each(function(idx, element) {
+      $(element).addClass('m-metric-group__collapsed');
+
+      var heading = $(element).find('.m-metric-group-header h2').clone();
+
+      var expandedContainer = $(element).find('[data-metric-group-expanded]');
+      var collapsedContainer = $('<div data-metric-group-collapsed>');
+
+      expandedContainer.hide();
+      collapsedContainer.append(heading);
+
+      $(element).append(collapsedContainer);
+
+      var openLink = $('<a href="#">Open</a>');
+      openLink.on('click', function(e) {
+        e.preventDefault();
+
+        collapsedContainer.hide();
+        expandedContainer.show();
+      });
+      collapsedContainer.append(openLink);
+    });
   }
 
   $(document).ready(function() {

--- a/app/assets/javascripts/collapsed_metric_group.js
+++ b/app/assets/javascripts/collapsed_metric_group.js
@@ -1,18 +1,5 @@
 (function() {
 
-  // Unescapes HTML entities.
-  //
-  // It's important that this function uses a `textarea` element to avoid
-  // introducing XSS vulnerabilities if this function is ever used with
-  // untrusted user input.
-  //
-  // See: https://stackoverflow.com/a/1395954
-  var decodeEntities = function(encodedString) {
-      var textArea = document.createElement('textarea');
-      textArea.innerHTML = encodedString;
-      return textArea.value;
-  }
-
   $.fn.collapsedMetricGroup = function() {
     // Determine which metric item has been sorted on. If we can't determine
     // it, then abort.
@@ -48,7 +35,7 @@
 
       // Populate the metric item description container, using HTML unescaped
       // content from the data attribute.
-      metricItemDescriptionContainer.html(decodeEntities(metricItemDescription));
+      metricItemDescriptionContainer.html(metricItemDescription);
       collapsedContainer.append(metricItemDescriptionContainer);
 
       // Create an open link, and give it a click behaviour to show the

--- a/app/assets/javascripts/collapsed_metric_group.js
+++ b/app/assets/javascripts/collapsed_metric_group.js
@@ -1,0 +1,11 @@
+(function() {
+
+  $.fn.collapsedMetricGroup = function() {
+    $(this).addClass('m-metric-group__collapsed');
+  }
+
+  $(document).ready(function() {
+    $('[data-behaviour="m-metric-group__collapsed"]').collapsedMetricGroup();
+  });
+
+})()

--- a/app/assets/javascripts/collapsed_metric_group.js
+++ b/app/assets/javascripts/collapsed_metric_group.js
@@ -1,19 +1,58 @@
 (function() {
 
+  // Unescapes HTML entities.
+  //
+  // It's important that this function uses a `textarea` element to avoid
+  // introducing XSS vulnerabilities if this function is ever used with
+  // untrusted user input.
+  //
+  // See: https://stackoverflow.com/a/1395954
+  var decodeEntities = function(encodedString) {
+      var textArea = document.createElement('textarea');
+      textArea.innerHTML = encodedString;
+      return textArea.value;
+  }
+
   $.fn.collapsedMetricGroup = function() {
+    // Determine which metric item has been sorted on. If we can't determine
+    // it, then abort.
+    var selectedMetricItem = $('[data-behaviour="o-filter-panel"] option:selected').val();
+    if(!selectedMetricItem) {
+      return;
+    }
+
     $(this).each(function(idx, element) {
-      $(element).addClass('m-metric-group__collapsed');
+      // Find the description for the selected metric item. If none is found
+      // then, continue with the next metric group.
+      var metricItem = $(element).find('[data-metric-item-identifier="' + selectedMetricItem + '"]');
+      var metricItemDescription = metricItem.data('metric-item-description');
+      if(!metricItemDescription) {
+        return;
+      }
 
-      var heading = $(element).find('.m-metric-group-header h2').clone();
-
+      // Find the "expanded" container, this has the full metric group
+      // information. Build the collapsed container with it's elements.
       var expandedContainer = $(element).find('[data-metric-group-expanded]');
-      var collapsedContainer = $('<div data-metric-group-collapsed>');
 
-      expandedContainer.hide();
-      collapsedContainer.append(heading);
+      var collapsedHeaderContainer = $("<div />", { class: 'm-metric-group-header' });
+      var metricItemDescriptionContainer = $('<div />', { class: 'm-metric-item-description' });
+      var openLinkContainer = $("<div />", { class: 'm-metric-group-open-toggle' });
+      var collapsedContainer = $('<div data-metric-group-collapsed>')
+                                 .addClass('m-metric-group__collapsed')
+                                 .append(collapsedHeaderContainer, metricItemDescriptionContainer, openLinkContainer);
 
-      $(element).append(collapsedContainer);
+      // Populate the collapsed header container, with the header from the
+      // expanded variant.
+      var heading = $(element).find('.m-metric-group-header h2').clone();
+      collapsedHeaderContainer.append(heading);
 
+      // Populate the metric item description container, using HTML unescaped
+      // content from the data attribute.
+      metricItemDescriptionContainer.html(decodeEntities(metricItemDescription));
+      collapsedContainer.append(metricItemDescriptionContainer);
+
+      // Create an open link, and give it a click behaviour to show the
+      // expanded variant.
       var openLink = $('<a href="#">Open</a>');
       openLink.on('click', function(e) {
         e.preventDefault();
@@ -21,7 +60,13 @@
         collapsedContainer.hide();
         expandedContainer.show();
       });
-      collapsedContainer.append(openLink);
+      openLinkContainer.append(openLink);
+      collapsedContainer.append(openLinkContainer);
+
+      // Add the collapsed container to the metric group, and hide the
+      // expanded container.
+      $(element).append(collapsedContainer);
+      expandedContainer.hide();
     });
   }
 

--- a/app/assets/stylesheets/_metric_group.scss
+++ b/app/assets/stylesheets/_metric_group.scss
@@ -1,0 +1,8 @@
+.m-metric-group {
+  border-bottom: 1px solid #BFC1C3;
+  padding: 0 15px;
+
+  h2 {
+    margin-bottom: 0;
+  }
+}

--- a/app/assets/stylesheets/_metric_group.scss
+++ b/app/assets/stylesheets/_metric_group.scss
@@ -6,3 +6,28 @@
     margin-bottom: 0;
   }
 }
+
+.m-metric-group__collapsed {
+  &> div { margin: 16px 0; }
+
+  .m-metric-group-header {
+    display: inline-block;
+    width: 50%;
+
+    h2 {
+      font-size: 19px;
+      margin: 0;
+    }
+  }
+
+  .m-metric-item-description {
+    display: inline-block;
+    width: 40%;
+  }
+
+  .m-metric-group-open-toggle {
+    display: inline-block;
+    width: 10%;
+    text-align: right;
+  }
+}

--- a/app/assets/stylesheets/_metric_group.scss
+++ b/app/assets/stylesheets/_metric_group.scss
@@ -12,6 +12,7 @@
 
   .m-metric-group-header {
     display: inline-block;
+    vertical-align: top;
     width: 50%;
 
     h2 {
@@ -22,11 +23,13 @@
 
   .m-metric-item-description {
     display: inline-block;
+    vertical-align: top;
     width: 40%;
   }
 
   .m-metric-group-open-toggle {
     display: inline-block;
+    vertical-align: top;
     width: 10%;
     text-align: right;
   }

--- a/app/assets/stylesheets/_metrics.scss
+++ b/app/assets/stylesheets/_metrics.scss
@@ -21,15 +21,6 @@ main {
       padding: 0;
     }
   }
-
-  .metric-group {
-    border-bottom: 1px solid #BFC1C3;
-    padding: 0 15px;
-
-    h2 {
-      margin-bottom: 0;
-    }
-  }
 }
 
 .m-metric ul li {

--- a/app/assets/stylesheets/screen.scss
+++ b/app/assets/stylesheets/screen.scss
@@ -2,5 +2,6 @@
 
 @import "time_period_selector";
 @import "metrics";
+@import "metric_group";
 @import "metrics_filter_panel";
 @import "tabs";

--- a/app/helpers/metric_item_helper.rb
+++ b/app/helpers/metric_item_helper.rb
@@ -1,0 +1,27 @@
+module MetricItemHelper
+  def metric_item(identifier, html: {}, &block)
+    item = MetricItem.new(self)
+    content = capture { block.call(item) }
+
+    html[:data] ||= {}
+    html[:data].merge!('metric-item-identifier' => identifier, 'metric-item-description' => item.description.try(:strip))
+
+    content_tag(:li, content, html)
+  end
+
+  private
+
+  class MetricItem < ActionView::Base
+    def initialize(helper = nil)
+      @helper = helper || self
+    end
+
+    def description(&content)
+      if content
+        @description = @helper.capture(&content)
+      else
+        @description
+      end
+    end
+  end
+end

--- a/app/models/metrics.rb
+++ b/app/models/metrics.rb
@@ -6,6 +6,18 @@ module Metrics
     Service = 'service'
   end
 
+  module Items
+    TransactionsReceived = 'transactions-received'
+    TransactionsReceivedOnline = 'transactions-received-online'
+    TransactionsReceivedPhone = 'transactions-received-phone'
+    TransactionsReceivedPaper = 'transactions-received-paper'
+    TransactionsReceivedFaceToFace = 'transactions-received-face-to-face'
+    TransactionsReceivedOther = 'transactions-received-other'
+
+    TransactionsEndingInOutcome = 'transactions-ending-in-outcome'
+    TransactionsEndingInOutcomeWithIntendedOutcome = 'transactions-ending-in-outcome-with-intended-outcome'
+  end
+
   module OrderBy
     private
     class Sorter
@@ -23,15 +35,15 @@ module Metrics
     end
 
     Name = Sorter.new('name', name: 'name', keypath: [:name])
-    TransactionsReceived = Sorter.new('transactions-received', name: 'transactions received', keypath: [:transactions_received, :total])
-    TransactionsReceivedOnline = Sorter.new('transactions-received-online', name: 'transactions received (online)', keypath: [:transactions_received, :online])
-    TransactionsReceivedPhone = Sorter.new('transactions-received-phone', name: 'transactions received (phone)', keypath: [:transactions_received, :phone])
-    TransactionsReceivedPaper = Sorter.new('transactions-received-paper', name: 'transactions received (paper)', keypath: [:transactions_received, :paper])
-    TransactionsReceivedFaceToFace = Sorter.new('transactions-received-face-to-face', name: 'transactions received (face to face)', keypath: [:transactions_received, :face_to_face])
-    TransactionsReceivedOther = Sorter.new('transactions-received-other', name: 'transactions received (other)', keypath: [:transactions_received, :other])
+    TransactionsReceived = Sorter.new(Items::TransactionsReceived, name: 'transactions received', keypath: [:transactions_received, :total])
+    TransactionsReceivedOnline = Sorter.new(Items::TransactionsReceivedOnline, name: 'transactions received (online)', keypath: [:transactions_received, :online])
+    TransactionsReceivedPhone = Sorter.new(Items::TransactionsReceivedPhone, name: 'transactions received (phone)', keypath: [:transactions_received, :phone])
+    TransactionsReceivedPaper = Sorter.new(Items::TransactionsReceivedPaper, name: 'transactions received (paper)', keypath: [:transactions_received, :paper])
+    TransactionsReceivedFaceToFace = Sorter.new(Items::TransactionsReceivedFaceToFace, name: 'transactions received (face to face)', keypath: [:transactions_received, :face_to_face])
+    TransactionsReceivedOther = Sorter.new(Items::TransactionsReceivedOther, name: 'transactions received (other)', keypath: [:transactions_received, :other])
 
-    TransactionsEndingInOutcome = Sorter.new('transactions-ending-in-outcome', name: 'transactions ending in an outcome', keypath: [:transactions_with_outcome, :count])
-    TransactionsEndingInOutcomeWithIntendedOutcome = Sorter.new('transactions-ending-in-outcome-with-intended-outcome',
+    TransactionsEndingInOutcome = Sorter.new(Items::TransactionsEndingInOutcome, name: 'transactions ending in an outcome', keypath: [:transactions_with_outcome, :count])
+    TransactionsEndingInOutcomeWithIntendedOutcome = Sorter.new(Items::TransactionsEndingInOutcomeWithIntendedOutcome,
       name: "transactions ending in the user's intended outcome",
       keypath: [:transactions_with_outcome, :count_with_intended_outcome]
     )

--- a/app/presenters/metric_group_presenter.rb
+++ b/app/presenters/metric_group_presenter.rb
@@ -11,8 +11,9 @@ class MetricGroupPresenter
     end
   end
 
-  def initialize(metric_group)
+  def initialize(metric_group, collapsed: false)
     @metric_group = metric_group
+    @collapsed = collapsed
   end
 
   def entity
@@ -40,5 +41,9 @@ class MetricGroupPresenter
     else
       nil
     end
+  end
+
+  def collapsed?
+    @collapsed ? true : false
   end
 end

--- a/app/presenters/metrics_presenter.rb
+++ b/app/presenters/metrics_presenter.rb
@@ -19,7 +19,7 @@ class MetricsPresenter
     @metric_groups ||= begin
       metric_groups = client
                         .metric_groups(entity, group_by: group_by)
-                        .map { |metric_group| MetricGroupPresenter.new(metric_group) }
+                        .map { |metric_group| MetricGroupPresenter.new(metric_group, collapsed: collapsed?) }
                         .sort_by(&sorter)
       metric_groups.reverse! if order == Metrics::Order::Descending
       metric_groups
@@ -65,4 +65,8 @@ class MetricsPresenter
   private
 
   attr_reader :client, :entity, :sorter
+
+  def collapsed?
+    order_by != Metrics::OrderBy::Name.identifier
+  end
 end

--- a/app/views/metric_groups/header/_delivery_organisation.html.erb
+++ b/app/views/metric_groups/header/_delivery_organisation.html.erb
@@ -1,2 +1,4 @@
-<h2 class="bold-medium"><%= link_to metric_group.name, delivery_organisation_metrics_path(metric_group.entity.key, group_by: Metrics::Group::Service) %></h2>
+<div class="m-metric-group-header">
+  <h2 class="bold-medium"><%= link_to metric_group.name, delivery_organisation_metrics_path(metric_group.entity.key, group_by: Metrics::Group::Service) %></h2>
 oversees <%= pluralize_link(metric_group.services_count, 'service', 'services', delivery_organisation_metrics_path(metric_group.entity.key, group_by: Metrics::Group::Service)) %>
+</div>

--- a/app/views/metric_groups/header/_department.html.erb
+++ b/app/views/metric_groups/header/_department.html.erb
@@ -1,2 +1,3 @@
-<h2 class="bold-medium"><%= link_to metric_group.name, department_metrics_path(metric_group.entity.key, group_by: Metrics::Group::DeliveryOrganisation) %></h2>
-oversees <%= pluralize_link(metric_group.delivery_organisations_count, 'delivery organisation', 'delivery organisations', department_metrics_path(metric_group.entity.key, group_by: Metrics::Group::DeliveryOrganisation)) %> and <%= pluralize_link(metric_group.services_count, 'service', 'services', department_metrics_path(metric_group.entity.key, group_by: Metrics::Group::Service)) %>
+<div class="m-metric-group-header">
+  <h2 class="bold-medium"><%= link_to metric_group.name, department_metrics_path(metric_group.entity.key, group_by: Metrics::Group::DeliveryOrganisation) %></h2> oversees <%= pluralize_link(metric_group.delivery_organisations_count, 'delivery organisation', 'delivery organisations', department_metrics_path(metric_group.entity.key, group_by: Metrics::Group::DeliveryOrganisation)) %> and <%= pluralize_link(metric_group.services_count, 'service', 'services', department_metrics_path(metric_group.entity.key, group_by: Metrics::Group::Service)) %>
+</div>

--- a/app/views/metric_groups/header/_service.html.erb
+++ b/app/views/metric_groups/header/_service.html.erb
@@ -1,1 +1,3 @@
-<h2 class="bold-medium"><%= link_to metric_group.name, service_path(metric_group.entity.key) %></h2>
+<div class="m-metric-group-header">
+  <h2 class="bold-medium"><%= link_to metric_group.name, service_path(metric_group.entity.key) %></h2>
+</div>

--- a/app/views/metrics/_transactions_received_metric.html.erb
+++ b/app/views/metrics/_transactions_received_metric.html.erb
@@ -1,13 +1,13 @@
 <div class="m-metric m-metric__transactions-received">
   <ul class="list">
-    <li class="m-metric-headline">
+    <li class="m-metric-headline" data-metric-item-identifier="transactions-received" data-metric-item-description="<strong><%= Rack::Utils.escape_html(metric_to_human(transactions_received_metric.total)) %></strong> transactions received">
       <span class="total">
         <span class="data-item bold-large"><%= metric_to_human(transactions_received_metric.total) %></span>
         <span class="data-item bold">transactions received</span>
       </span>
     </li>
 
-    <li>
+    <li data-metric-item-identifier="transactions-received-online" data-metric-item-description="<strong><%= Rack::Utils.escape_html(metric_to_human(transactions_received_metric.online)) %></strong> online transactions (<%= Rack::Utils.escape_html(metric_to_percentage(transactions_received_metric.online_percentage)) %>)">
       <span class="metric-name">Online</span>
       <span class="metric-value">
         <span class="metric-value-count"><%= metric_to_human(transactions_received_metric.online) %></span>
@@ -15,7 +15,7 @@
       </span>
     </li>
 
-    <li>
+    <li data-metric-item-identifier="transactions-received-phone" data-metric-item-description="<strong><%= Rack::Utils.escape_html(metric_to_human(transactions_received_metric.phone)) %></strong> phone transactions (<%= Rack::Utils.escape_html(metric_to_percentage(transactions_received_metric.phone_percentage)) %>)">
       <span class="metric-name">Phone</span>
       <span class="metric-value">
         <span class="metric-value-count"><%= metric_to_human(transactions_received_metric.phone) %></span>
@@ -23,7 +23,7 @@
       </span>
     </li>
 
-    <li>
+    <li data-metric-item-identifier="transactions-received-paper" data-metric-item-description="<strong><%= Rack::Utils.escape_html(metric_to_human(transactions_received_metric.paper)) %></strong> paper transactions (<%= Rack::Utils.escape_html(metric_to_percentage(transactions_received_metric.paper_percentage)) %>)">
       <span class="metric-name">Paper</span>
       <span class="metric-value">
         <span class="metric-value-count"><%= metric_to_human(transactions_received_metric.paper) %></span>
@@ -31,7 +31,7 @@
       </span>
     </li>
 
-    <li>
+    <li data-metric-item-identifier="transactions-received-face-to-face" data-metric-item-description="<strong><%= Rack::Utils.escape_html(metric_to_human(transactions_received_metric.face_to_face)) %></strong> face to face transactions (<%= Rack::Utils.escape_html(metric_to_percentage(transactions_received_metric.face_to_face_percentage)) %>)">
       <span class="metric-name">Face to Face</span>
       <span class="metric-value">
         <span class="metric-value-count"><%= metric_to_human(transactions_received_metric.face_to_face) %></span>
@@ -39,7 +39,7 @@
       </span>
     </li>
 
-    <li>
+    <li data-metric-item-identifier="transactions-received-other" data-metric-item-description="<strong><%= Rack::Utils.escape_html(metric_to_human(transactions_received_metric.other)) %></strong> other transactions (<%= Rack::Utils.escape_html(metric_to_percentage(transactions_received_metric.other_percentage)) %>)">
       <span class="metric-name">Other</span>
       <span class="metric-value">
         <span class="metric-value-count"><%= metric_to_human(transactions_received_metric.other) %></span>

--- a/app/views/metrics/_transactions_received_metric.html.erb
+++ b/app/views/metrics/_transactions_received_metric.html.erb
@@ -1,50 +1,74 @@
 <div class="m-metric m-metric__transactions-received">
   <ul class="list">
-    <li class="m-metric-headline" data-metric-item-identifier="transactions-received" data-metric-item-description="<strong><%= Rack::Utils.escape_html(metric_to_human(transactions_received_metric.total)) %></strong> transactions received">
+    <%= metric_item('transactions-received', html: { class: 'm-metric-headline' }) do |item| %>
+      <% item.description do %>
+        <strong><%= metric_to_human(transactions_received_metric.total) %></strong> transactions received
+      <% end %>
+
       <span class="total">
         <span class="data-item bold-large"><%= metric_to_human(transactions_received_metric.total) %></span>
         <span class="data-item bold">transactions received</span>
       </span>
-    </li>
+    <% end %>
 
-    <li data-metric-item-identifier="transactions-received-online" data-metric-item-description="<strong><%= Rack::Utils.escape_html(metric_to_human(transactions_received_metric.online)) %></strong> online transactions (<%= Rack::Utils.escape_html(metric_to_percentage(transactions_received_metric.online_percentage)) %>)">
+    <%= metric_item('transactions-received-online') do |item| %>
+      <% item.description do %>
+        <strong><%= metric_to_human(transactions_received_metric.online) %></strong> online transactions (<%= metric_to_percentage(transactions_received_metric.online_percentage) %>)
+      <% end %>
+
       <span class="metric-name">Online</span>
       <span class="metric-value">
         <span class="metric-value-count"><%= metric_to_human(transactions_received_metric.online) %></span>
         <span class="metric-value-percentage">(<%= metric_to_percentage(transactions_received_metric.online_percentage) %>)</span>
       </span>
-    </li>
+    <% end %>
 
-    <li data-metric-item-identifier="transactions-received-phone" data-metric-item-description="<strong><%= Rack::Utils.escape_html(metric_to_human(transactions_received_metric.phone)) %></strong> phone transactions (<%= Rack::Utils.escape_html(metric_to_percentage(transactions_received_metric.phone_percentage)) %>)">
+    <%= metric_item('transactions-received-phone') do |item| %>
+      <% item.description do %>
+        <strong><%= metric_to_human(transactions_received_metric.phone) %></strong> phone transactions (<%= metric_to_percentage(transactions_received_metric.phone_percentage) %>)
+      <% end %>
+
       <span class="metric-name">Phone</span>
       <span class="metric-value">
         <span class="metric-value-count"><%= metric_to_human(transactions_received_metric.phone) %></span>
         <span class="metric-value-percentage">(<%= metric_to_percentage(transactions_received_metric.phone_percentage) %>)</span>
       </span>
-    </li>
+    <% end %>
 
-    <li data-metric-item-identifier="transactions-received-paper" data-metric-item-description="<strong><%= Rack::Utils.escape_html(metric_to_human(transactions_received_metric.paper)) %></strong> paper transactions (<%= Rack::Utils.escape_html(metric_to_percentage(transactions_received_metric.paper_percentage)) %>)">
+    <%= metric_item('transactions-received-paper') do |item| %>
+      <% item.description do %>
+        <strong><%= metric_to_human(transactions_received_metric.paper) %></strong> paper transactions (<%= metric_to_percentage(transactions_received_metric.paper_percentage) %>)
+      <% end %>
+
       <span class="metric-name">Paper</span>
       <span class="metric-value">
         <span class="metric-value-count"><%= metric_to_human(transactions_received_metric.paper) %></span>
         <span class="metric-value-percentage">(<%= metric_to_percentage(transactions_received_metric.paper_percentage) %>)</span>
       </span>
-    </li>
+    <% end %>
 
-    <li data-metric-item-identifier="transactions-received-face-to-face" data-metric-item-description="<strong><%= Rack::Utils.escape_html(metric_to_human(transactions_received_metric.face_to_face)) %></strong> face to face transactions (<%= Rack::Utils.escape_html(metric_to_percentage(transactions_received_metric.face_to_face_percentage)) %>)">
+    <%= metric_item('transactions-received-face-to-face') do |item| %>
+      <% item.description do %>
+        <strong><%= metric_to_human(transactions_received_metric.face_to_face) %></strong> face to face transactions (<%= metric_to_percentage(transactions_received_metric.face_to_face_percentage) %>)
+      <% end %>
+
       <span class="metric-name">Face to Face</span>
       <span class="metric-value">
         <span class="metric-value-count"><%= metric_to_human(transactions_received_metric.face_to_face) %></span>
         <span class="metric-value-percentage">(<%= metric_to_percentage(transactions_received_metric.face_to_face_percentage) %>)</span>
       </span>
-    </li>
+    <% end %>
 
-    <li data-metric-item-identifier="transactions-received-other" data-metric-item-description="<strong><%= Rack::Utils.escape_html(metric_to_human(transactions_received_metric.other)) %></strong> other transactions (<%= Rack::Utils.escape_html(metric_to_percentage(transactions_received_metric.other_percentage)) %>)">
+    <%= metric_item('transactions-received-other') do |item| %>
+      <% item.description do %>
+        <strong><%= metric_to_human(transactions_received_metric.other) %></strong> other transactions (<%= metric_to_percentage(transactions_received_metric.other_percentage) %>)
+      <% end %>
+
       <span class="metric-name">Other</span>
       <span class="metric-value">
         <span class="metric-value-count"><%= metric_to_human(transactions_received_metric.other) %></span>
         <span class="metric-value-percentage">(<%= metric_to_percentage(transactions_received_metric.other_percentage) %>)</span>
       </span>
-    </li>
+    <% end %>
   </ul>
 </div>

--- a/app/views/metrics/_transactions_received_metric.html.erb
+++ b/app/views/metrics/_transactions_received_metric.html.erb
@@ -1,6 +1,6 @@
 <div class="m-metric m-metric__transactions-received">
   <ul class="list">
-    <%= metric_item('transactions-received', html: { class: 'm-metric-headline' }) do |item| %>
+    <%= metric_item(Metrics::Items::TransactionsReceived, html: { class: 'm-metric-headline' }) do |item| %>
       <% item.description do %>
         <strong><%= metric_to_human(transactions_received_metric.total) %></strong> transactions received
       <% end %>
@@ -11,7 +11,7 @@
       </span>
     <% end %>
 
-    <%= metric_item('transactions-received-online') do |item| %>
+    <%= metric_item(Metrics::Items::TransactionsReceivedOnline) do |item| %>
       <% item.description do %>
         <strong><%= metric_to_human(transactions_received_metric.online) %></strong> online transactions (<%= metric_to_percentage(transactions_received_metric.online_percentage) %>)
       <% end %>
@@ -23,7 +23,7 @@
       </span>
     <% end %>
 
-    <%= metric_item('transactions-received-phone') do |item| %>
+    <%= metric_item(Metrics::Items::TransactionsReceivedPhone) do |item| %>
       <% item.description do %>
         <strong><%= metric_to_human(transactions_received_metric.phone) %></strong> phone transactions (<%= metric_to_percentage(transactions_received_metric.phone_percentage) %>)
       <% end %>
@@ -35,7 +35,7 @@
       </span>
     <% end %>
 
-    <%= metric_item('transactions-received-paper') do |item| %>
+    <%= metric_item(Metrics::Items::TransactionsReceivedPaper) do |item| %>
       <% item.description do %>
         <strong><%= metric_to_human(transactions_received_metric.paper) %></strong> paper transactions (<%= metric_to_percentage(transactions_received_metric.paper_percentage) %>)
       <% end %>
@@ -47,7 +47,7 @@
       </span>
     <% end %>
 
-    <%= metric_item('transactions-received-face-to-face') do |item| %>
+    <%= metric_item(Metrics::Items::TransactionsReceivedFaceToFace) do |item| %>
       <% item.description do %>
         <strong><%= metric_to_human(transactions_received_metric.face_to_face) %></strong> face to face transactions (<%= metric_to_percentage(transactions_received_metric.face_to_face_percentage) %>)
       <% end %>
@@ -59,7 +59,7 @@
       </span>
     <% end %>
 
-    <%= metric_item('transactions-received-other') do |item| %>
+    <%= metric_item(Metrics::Items::TransactionsReceivedOther) do |item| %>
       <% item.description do %>
         <strong><%= metric_to_human(transactions_received_metric.other) %></strong> other transactions (<%= metric_to_percentage(transactions_received_metric.other_percentage) %>)
       <% end %>

--- a/app/views/metrics/_transactions_with_outcome_metric.html.erb
+++ b/app/views/metrics/_transactions_with_outcome_metric.html.erb
@@ -1,6 +1,6 @@
 <div class="m-metric m-metric__transactions-with-outcome">
   <ul class="list">
-    <%= metric_item('transactions-ending-in-outcome', html: { class: 'm-metric-headline' }) do |item| %>
+    <%= metric_item(Metrics::Items::TransactionsEndingInOutcome, html: { class: 'm-metric-headline' }) do |item| %>
       <% item.description do %>
         <strong><%= metric_to_human(transactions_with_outcome_metric.count) %></strong> transactions ending in an outcome
       <% end %>
@@ -11,7 +11,7 @@
       </span>
     <% end %>
 
-    <%= metric_item('transactions-ending-in-outcome-with-intended-outcome') do |item| %>
+    <%= metric_item(Metrics::Items::TransactionsEndingInOutcomeWithIntendedOutcome) do |item| %>
       <% item.description do %>
         <strong><%= metric_to_human(transactions_with_outcome_metric.count_with_intended_outcome) %></strong> transactions with intended outcome (<%= metric_to_percentage(transactions_with_outcome_metric.with_intended_outcome_percentage) %>)
       <% end %>

--- a/app/views/metrics/_transactions_with_outcome_metric.html.erb
+++ b/app/views/metrics/_transactions_with_outcome_metric.html.erb
@@ -1,17 +1,26 @@
 <div class="m-metric m-metric__transactions-with-outcome">
   <ul class="list">
-    <li class="m-metric-headline" data-metric-item-identifier="transactions-ending-in-outcome" data-metric-item-description="<strong><%= Rack::Utils.escape_html(metric_to_human(transactions_with_outcome_metric.count)) %></strong> transactions ending in an outcome">
+    <%= metric_item('transactions-ending-in-outcome', html: { class: 'm-metric-headline' }) do |item| %>
+      <% item.description do %>
+        <strong><%= metric_to_human(transactions_with_outcome_metric.count) %></strong> transactions ending in an outcome
+      <% end %>
+
       <span class="total">
         <span class="data-item bold-large"><%= metric_to_human(transactions_with_outcome_metric.count) %></span>
         <span class="data-item bold">transactions ending in an outcome</span>
       </span>
-    </li>
-    <li data-metric-item-identifier="transactions-ending-in-outcome-with-intended-outcome" data-metric-item-description="<strong><%= Rack::Utils.escape_html(metric_to_human(transactions_with_outcome_metric.count_with_intended_outcome)) %></strong> transactions with intended outcome (<%= Rack::Utils.escape_html(metric_to_percentage(transactions_with_outcome_metric.with_intended_outcome_percentage)) %>)">
+    <% end %>
+
+    <%= metric_item('transactions-ending-in-outcome-with-intended-outcome') do |item| %>
+      <% item.description do %>
+        <strong><%= metric_to_human(transactions_with_outcome_metric.count_with_intended_outcome) %></strong> transactions with intended outcome (<%= metric_to_percentage(transactions_with_outcome_metric.with_intended_outcome_percentage) %>)
+      <% end %>
+
       <span class="metric-name">Ending in the user&apos;s intended outcome</span>
       <span class="metric-value">
         <span class="metric-value-count"><%= metric_to_human(transactions_with_outcome_metric.count_with_intended_outcome) %></span>
         <span class="metric-value-percentage">(<%= metric_to_percentage(transactions_with_outcome_metric.with_intended_outcome_percentage) %>)</span>
       </span>
-    </li>
+    <% end %>
   </ul>
 </div>

--- a/app/views/metrics/_transactions_with_outcome_metric.html.erb
+++ b/app/views/metrics/_transactions_with_outcome_metric.html.erb
@@ -1,12 +1,12 @@
 <div class="m-metric m-metric__transactions-with-outcome">
   <ul class="list">
-    <li class="m-metric-headline">
+    <li class="m-metric-headline" data-metric-item-identifier="transactions-ending-in-outcome" data-metric-item-description="<strong><%= Rack::Utils.escape_html(metric_to_human(transactions_with_outcome_metric.count)) %></strong> transactions ending in an outcome">
       <span class="total">
         <span class="data-item bold-large"><%= metric_to_human(transactions_with_outcome_metric.count) %></span>
         <span class="data-item bold">transactions ending in an outcome</span>
       </span>
     </li>
-    <li>
+    <li data-metric-item-identifier="transactions-ending-in-outcome-with-intended-outcome" data-metric-item-description="<strong><%= Rack::Utils.escape_html(metric_to_human(transactions_with_outcome_metric.count_with_intended_outcome)) %></strong> transactions with intended outcome (<%= Rack::Utils.escape_html(metric_to_percentage(transactions_with_outcome_metric.with_intended_outcome_percentage)) %>)">
       <span class="metric-name">Ending in the user&apos;s intended outcome</span>
       <span class="metric-value">
         <span class="metric-value-count"><%= metric_to_human(transactions_with_outcome_metric.count_with_intended_outcome) %></span>

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -60,7 +60,7 @@
     <ul>
 
       <% @metrics.metric_groups.each do |metric_group|  %>
-        <li class="m-metric-group">
+        <li class="m-metric-group" <% if metric_group.collapsed? %>data-behaviour="m-metric-group__collapsed"<% end %>>
           <%= render metric_group.entity, metric_group: metric_group  %>
 
           <div class="m-metrics">

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -61,10 +61,12 @@
 
       <% @metrics.metric_groups.each do |metric_group|  %>
         <li class="m-metric-group" <% if metric_group.collapsed? %>data-behaviour="m-metric-group__collapsed"<% end %>>
-          <%= render metric_group.entity, metric_group: metric_group  %>
+          <div data-metric-group-expanded>
+            <%= render metric_group.entity, metric_group: metric_group  %>
 
-          <div class="m-metrics">
-            <%= render metric_group.metrics %>
+            <div class="m-metrics">
+              <%= render metric_group.metrics %>
+            </div>
           </div>
         </li>
       <% end %>

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -60,7 +60,7 @@
     <ul>
 
       <% @metrics.metric_groups.each do |metric_group|  %>
-        <li class="metric-group">
+        <li class="m-metric-group">
           <%= render metric_group.entity, metric_group: metric_group  %>
 
           <div class="m-metrics">

--- a/spec/features/viewing_metrics_spec.rb
+++ b/spec/features/viewing_metrics_spec.rb
@@ -62,7 +62,6 @@ RSpec.feature 'viewing metrics', type: :feature do
 
       select 'transactions received', from: 'Sort by'
       expect(page).to have_selector('.m-metric-group[data-behaviour="m-metric-group__collapsed"]', count: 7)
-      expect(page).to have_selector('.m-metric-group.m-metric-group__collapsed', count: 7)
     end
   end
 

--- a/spec/features/viewing_metrics_spec.rb
+++ b/spec/features/viewing_metrics_spec.rb
@@ -21,6 +21,8 @@ RSpec.feature 'viewing metrics', type: :feature do
         select 'transactions received', from: 'Sort by'
         click_on 'Apply' unless javascript_enabled
 
+        all('a', text: /\AOpen\z/).each(&:click) if javascript_enabled
+
         expect(metric_groups(:name, :transactions_received_total)).to eq([
           ['HM Revenue & Customs',                                          '0'],
           ['Department for Business, Energy & Industrial Strategy',         '0'],
@@ -37,6 +39,8 @@ RSpec.feature 'viewing metrics', type: :feature do
           choose 'High to Low'
         end
         click_on 'Apply' unless javascript_enabled
+
+        all('a', text: /\AOpen\z/).each(&:click) if javascript_enabled
 
         expect(metric_groups(:name, :transactions_received_total)).to eq([
           ['Ministry of Justice',                                   '593254687'],

--- a/spec/features/viewing_metrics_spec.rb
+++ b/spec/features/viewing_metrics_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature 'viewing metrics', type: :feature do
   def metric_groups(*attrs)
     attributes = ->(metric_group) { attrs.map {|attribute| metric_group.send(attribute) } }
 
-    all('.metric-group', count: 7)
+    all('.m-metric-group', count: 7)
       .map { |element| MetricGroup.new(element) }
       .collect(&attributes)
   end

--- a/spec/features/viewing_metrics_spec.rb
+++ b/spec/features/viewing_metrics_spec.rb
@@ -49,6 +49,17 @@ RSpec.feature 'viewing metrics', type: :feature do
         ])
       end
     end
+
+    it 'collapses metric groups, when sorting by attributes (other than name)', cassette: 'viewing-metrics-collapsing-metric-groups', js: true do
+      visit government_metrics_path(group_by: Metrics::Group::Department)
+
+      expect(page).to have_selector('.m-metric-group', count: 7)
+      expect(page).to have_selector('.m-metric-group[data-behaviour="m-metric-group__collapsed"]', count: 0)
+
+      select 'transactions received', from: 'Sort by'
+      expect(page).to have_selector('.m-metric-group[data-behaviour="m-metric-group__collapsed"]', count: 7)
+      expect(page).to have_selector('.m-metric-group.m-metric-group__collapsed', count: 7)
+    end
   end
 
   private

--- a/spec/fixtures/vcr/viewing-metrics-collapsing-metric-groups.yml
+++ b/spec/fixtures/vcr/viewing-metrics-collapsing-metric-groups.yml
@@ -1,0 +1,181 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://cgsd-api-rails.dev/v1/data/government
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic dGVzdDp0ZXN0
+      User-Agent:
+      - Faraday v0.12.1
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"8707143287988501f058572a4a858fbd"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 0a560b19-ec36-4acd-b1d4-fd6e97f54fa5
+      x-runtime:
+      - '0.004254'
+      date:
+      - Wed, 05 Jul 2017 12:53:37 GMT
+      connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"type":"government","departments_count":7,"delivery_organisations_count":8,"services_count":31}'
+    http_version: 
+  recorded_at: Wed, 05 Jul 2017 12:53:37 GMT
+- request:
+    method: get
+    uri: http://cgsd-api-rails.dev/v1/data/government/metrics?group_by=department
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic dGVzdDp0ZXN0
+      User-Agent:
+      - Faraday v0.12.1
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"a7ef738adddffceed6651e49a5654be6"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 41682a9d-7151-4e5e-8926-35514bcc7ed9
+      x-runtime:
+      - '0.049037'
+      date:
+      - Wed, 05 Jul 2017 12:53:37 GMT
+      connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"group_by":"department","metric_groups":[{"entity":{"type":"department","natural_key":"D0001","name":"Department
+        for Environment Food \u0026 Rural Affairs","hostname":"department-for-environment-food-and-rural-affairs","delivery_organisations_count":1,"services_count":1},"metrics":[{"type":"transactions-received","total":3000039,"online":1000032,"phone":1000003,"paper":1000004,"face_to_face":0,"other":0},{"type":"transactions-with-outcome","total":2435098,"with_intended_outcome":2400000}]},{"entity":{"type":"department","natural_key":"D0002","name":"Department
+        for Transport","hostname":"department-for-transport","delivery_organisations_count":2,"services_count":9},"metrics":[{"type":"transactions-received","total":118679511,"online":70711048,"phone":10123774,"paper":17857035,"face_to_face":0,"other":19987654},{"type":"transactions-with-outcome","total":114587788,"with_intended_outcome":92321116}]},{"entity":{"type":"department","natural_key":"D0003","name":"Department
+        of Health","hostname":"department-of-health","delivery_organisations_count":2,"services_count":4},"metrics":[{"type":"transactions-received","total":18132669,"online":4000048,"phone":14132621,"paper":0,"face_to_face":0,"other":0},{"type":"transactions-with-outcome","total":19281820,"with_intended_outcome":15424926}]},{"entity":{"type":"department","natural_key":"D0004","name":"HM
+        Revenue \u0026 Customs","hostname":"hm-revenue-and-customs","delivery_organisations_count":0,"services_count":5},"metrics":[{"type":"transactions-received","total":0,"online":0,"phone":0,"paper":0,"face_to_face":0,"other":0},{"type":"transactions-with-outcome","total":0,"with_intended_outcome":0}]},{"entity":{"type":"department","natural_key":"D0005","name":"Ministry
+        of Justice","hostname":"ministry-of-justice","delivery_organisations_count":1,"services_count":5},"metrics":[{"type":"transactions-received","total":593254687,"online":566114271,"phone":9098765,"paper":14918195,"face_to_face":0,"other":3123456},{"type":"transactions-with-outcome","total":562002435,"with_intended_outcome":485131983}]},{"entity":{"type":"department","natural_key":"D0006","name":"Department
+        for Education","hostname":"department-for-education","delivery_organisations_count":2,"services_count":7},"metrics":[{"type":"transactions-received","total":13000475,"online":7000282,"phone":4000106,"paper":2000087,"face_to_face":0,"other":0},{"type":"transactions-with-outcome","total":12120242,"with_intended_outcome":9536719}]},{"entity":{"type":"department","natural_key":"D0007","name":"Department
+        for Business, Energy \u0026 Industrial Strategy","hostname":"department-for-business-energy-and-industrial-strategy","delivery_organisations_count":0,"services_count":0},"metrics":[{"type":"transactions-received","total":0,"online":0,"phone":0,"paper":0,"face_to_face":0,"other":0},{"type":"transactions-with-outcome","total":0,"with_intended_outcome":0}]}]}'
+    http_version: 
+  recorded_at: Wed, 05 Jul 2017 12:53:37 GMT
+- request:
+    method: get
+    uri: http://cgsd-api-rails.dev/v1/data/government
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic dGVzdDp0ZXN0
+      User-Agent:
+      - Faraday v0.12.1
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"8707143287988501f058572a4a858fbd"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - f33f1cce-7633-4b9d-816d-84870d27eb14
+      x-runtime:
+      - '0.003853'
+      date:
+      - Wed, 05 Jul 2017 12:53:42 GMT
+      connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"type":"government","departments_count":7,"delivery_organisations_count":8,"services_count":31}'
+    http_version: 
+  recorded_at: Wed, 05 Jul 2017 12:53:42 GMT
+- request:
+    method: get
+    uri: http://cgsd-api-rails.dev/v1/data/government/metrics?group_by=department
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic dGVzdDp0ZXN0
+      User-Agent:
+      - Faraday v0.12.1
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"a7ef738adddffceed6651e49a5654be6"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 608ab71d-4fb2-4716-a15f-8808f0c2dd82
+      x-runtime:
+      - '0.041014'
+      date:
+      - Wed, 05 Jul 2017 12:53:42 GMT
+      connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"group_by":"department","metric_groups":[{"entity":{"type":"department","natural_key":"D0001","name":"Department
+        for Environment Food \u0026 Rural Affairs","hostname":"department-for-environment-food-and-rural-affairs","delivery_organisations_count":1,"services_count":1},"metrics":[{"type":"transactions-received","total":3000039,"online":1000032,"phone":1000003,"paper":1000004,"face_to_face":0,"other":0},{"type":"transactions-with-outcome","total":2435098,"with_intended_outcome":2400000}]},{"entity":{"type":"department","natural_key":"D0002","name":"Department
+        for Transport","hostname":"department-for-transport","delivery_organisations_count":2,"services_count":9},"metrics":[{"type":"transactions-received","total":118679511,"online":70711048,"phone":10123774,"paper":17857035,"face_to_face":0,"other":19987654},{"type":"transactions-with-outcome","total":114587788,"with_intended_outcome":92321116}]},{"entity":{"type":"department","natural_key":"D0003","name":"Department
+        of Health","hostname":"department-of-health","delivery_organisations_count":2,"services_count":4},"metrics":[{"type":"transactions-received","total":18132669,"online":4000048,"phone":14132621,"paper":0,"face_to_face":0,"other":0},{"type":"transactions-with-outcome","total":19281820,"with_intended_outcome":15424926}]},{"entity":{"type":"department","natural_key":"D0004","name":"HM
+        Revenue \u0026 Customs","hostname":"hm-revenue-and-customs","delivery_organisations_count":0,"services_count":5},"metrics":[{"type":"transactions-received","total":0,"online":0,"phone":0,"paper":0,"face_to_face":0,"other":0},{"type":"transactions-with-outcome","total":0,"with_intended_outcome":0}]},{"entity":{"type":"department","natural_key":"D0005","name":"Ministry
+        of Justice","hostname":"ministry-of-justice","delivery_organisations_count":1,"services_count":5},"metrics":[{"type":"transactions-received","total":593254687,"online":566114271,"phone":9098765,"paper":14918195,"face_to_face":0,"other":3123456},{"type":"transactions-with-outcome","total":562002435,"with_intended_outcome":485131983}]},{"entity":{"type":"department","natural_key":"D0006","name":"Department
+        for Education","hostname":"department-for-education","delivery_organisations_count":2,"services_count":7},"metrics":[{"type":"transactions-received","total":13000475,"online":7000282,"phone":4000106,"paper":2000087,"face_to_face":0,"other":0},{"type":"transactions-with-outcome","total":12120242,"with_intended_outcome":9536719}]},{"entity":{"type":"department","natural_key":"D0007","name":"Department
+        for Business, Energy \u0026 Industrial Strategy","hostname":"department-for-business-energy-and-industrial-strategy","delivery_organisations_count":0,"services_count":0},"metrics":[{"type":"transactions-received","total":0,"online":0,"phone":0,"paper":0,"face_to_face":0,"other":0},{"type":"transactions-with-outcome","total":0,"with_intended_outcome":0}]}]}'
+    http_version: 
+  recorded_at: Wed, 05 Jul 2017 12:53:42 GMT
+recorded_with: VCR 3.0.3

--- a/spec/helpers/metric_item_helper_spec.rb
+++ b/spec/helpers/metric_item_helper_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe MetricItemHelper, type: :helper do
+  describe '#metric_item' do
+    let(:identifier) { 'transactions-received' }
+
+    it 'wraps the content in an <li>' do
+      output = metric_item(identifier) do
+        "<p>Content</p>".html_safe
+      end
+
+      expect(output).to have_selector('li p')
+    end
+
+    it 'passes html options to the content tag' do
+      output = metric_item(identifier, html: { class: 'optional-class' }) {}
+      expect(output).to have_selector('li.optional-class')
+    end
+
+    it 'includes the identifier as a data attribute' do
+      output = metric_item(identifier) {}
+      expect(output).to have_selector('li[data-metric-item-identifier="transactions-received"]')
+    end
+
+    it 'includes the description as a data attribute' do
+      output = metric_item(identifier) do |item|
+        item.description do
+          '<strong>transactions-received</strong> description'
+        end
+      end
+
+      escaped_description = '&lt;strong&gt;transactions-received&lt;/strong&gt; description'
+      expect(output).to have_selector(%Q{li[data-metric-item-description="#{escaped_description}"]})
+    end
+  end
+end

--- a/spec/presenters/metric_group_presenter_spec.rb
+++ b/spec/presenters/metric_group_presenter_spec.rb
@@ -49,4 +49,15 @@ RSpec.describe MetricGroupPresenter, type: :presenter do
       expect(presenter.services_count).to be_nil
     end
   end
+
+  describe '#collapsed?' do
+    it "isn't collapsed by default" do
+      expect(presenter).to_not be_collapsed
+    end
+
+    it "can be set to collapsed" do
+      presenter = MetricGroupPresenter.new(metric_group, collapsed: true)
+      expect(presenter).to be_collapsed
+    end
+  end
 end

--- a/spec/presenters/metrics_presenter_spec.rb
+++ b/spec/presenters/metrics_presenter_spec.rb
@@ -56,13 +56,24 @@ RSpec.describe MetricsPresenter do
 
       metric_group_presenter_1 = instance_double(MetricGroupPresenter)
       metric_group_presenter_2 = instance_double(MetricGroupPresenter)
-      expect(MetricGroupPresenter).to receive(:new).with(metric_group_1) { metric_group_presenter_1 }
-      expect(MetricGroupPresenter).to receive(:new).with(metric_group_2) { metric_group_presenter_2 }
+      expect(MetricGroupPresenter).to receive(:new).with(metric_group_1, collapsed: false) { metric_group_presenter_1 }
+      expect(MetricGroupPresenter).to receive(:new).with(metric_group_2, collapsed: false) { metric_group_presenter_2 }
 
       sorter = ->(_) {}
       allow(Metrics::OrderBy).to receive(:fetch) { sorter }
 
       expect(presenter.metric_groups).to match_array([metric_group_presenter_1, metric_group_presenter_2])
+    end
+
+    it "sets the metric group to be collapsed if it isn't ordered by name" do
+      metric_group = instance_double(CrossGovernmentServiceDataAPI::MetricGroup)
+      allow(client).to receive(:metric_groups) { [metric_group] }
+
+      expect(MetricGroupPresenter).to receive(:new).with(metric_group, collapsed: true) { instance_double(MetricGroupPresenter) }
+
+      allow(Metrics::OrderBy).to receive(:fetch) { ->(_) {} }
+      presenter = described_class.new(entity, client: client, group_by: group_by, order_by: 'alternative metric')
+      presenter.metric_groups
     end
 
     describe 'sorting' do

--- a/spec/support/metric_group_header_shared_examples.rb
+++ b/spec/support/metric_group_header_shared_examples.rb
@@ -1,0 +1,18 @@
+RSpec.shared_examples_for 'metric group header' do
+  let(:entity) { double('entity', key: 'ABC123') }
+  let(:metric_group) { instance_double(MetricGroupPresenter, name: 'Metric Group Name', entity: entity, delivery_organisations_count: 83, services_count: 93) }
+
+  def render
+    super(partial: partial, locals: { metric_group: metric_group })
+  end
+
+  it "has a 'm-metric-group-header' container"  do |example|
+    render
+    expect(rendered).to have_selector('.m-metric-group-header')
+  end
+
+  it 'has a heading' do
+    render
+    expect(rendered).to have_selector('.m-metric-group-header h2', text: 'Metric Group Name')
+  end
+end

--- a/spec/views/metric_groups/header/_delivery_organisation.html.erb_spec.rb
+++ b/spec/views/metric_groups/header/_delivery_organisation.html.erb_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe 'metric_groups/header/_delivery_organisation.html.erb', type: :view do
+  it_behaves_like 'metric group header' do
+    let(:partial) { 'metric_groups/header/delivery_organisation' }
+  end
+end

--- a/spec/views/metric_groups/header/_department.html.erb_spec.rb
+++ b/spec/views/metric_groups/header/_department.html.erb_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe 'metric_groups/header/_department.html.erb', type: :view do
+  it_behaves_like 'metric group header' do
+    let(:partial) { 'metric_groups/header/department' }
+  end
+end

--- a/spec/views/metric_groups/header/_service.html.erb_spec.rb
+++ b/spec/views/metric_groups/header/_service.html.erb_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe 'metric_groups/header/_service.html.erb', type: :view do
+  it_behaves_like 'metric group header' do
+    let(:partial) { 'metric_groups/header/service' }
+  end
+end


### PR DESCRIPTION
When an attribute is selected for sorting – other than the name – collapse the metric groups to only show a single metric.