### PR TITLE
Standardise text alignment on metric group page

### DIFF
--- a/app/assets/javascripts/__tests__/search.test.js
+++ b/app/assets/javascripts/__tests__/search.test.js
@@ -17,7 +17,7 @@ describe('On the search page', function () {
     '</div>'
 
   var SearchResultsHTML =
-    '<div class="o-metric-groups grid-row" data-behaviour="o-metric-groups">' +
+    '<div class="o-metric-groups" data-behaviour="o-metric-groups">' +
       '<ul>' +
         '<li class="m-metric-group" data-behaviour="m-metric-group">' +
           '<h2 class="bold-medium"><a>HM Revenue &amp; Customs</a></h2>' +

--- a/app/assets/stylesheets/_metric_group.scss
+++ b/app/assets/stylesheets/_metric_group.scss
@@ -1,6 +1,5 @@
 .m-metric-group {
   border-bottom: 1px solid #BFC1C3;
-  padding: 0 15px;
 
   h2 {
     margin-bottom: 0;

--- a/app/assets/stylesheets/_metrics_filter_panel.scss
+++ b/app/assets/stylesheets/_metrics_filter_panel.scss
@@ -118,8 +118,8 @@
 
 .o-filter-panel {
   border-top: 1px solid $grey-2;
-  padding: 10px 15px;
-
+  padding-top: 10px;
+  padding-bottom: 10px;
 
   form {
     padding: 0;

--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -16,7 +16,7 @@ module TabsHelper
       end
     end
 
-    content_tag(:nav, class: 'o-tabs grid-row') do
+    content_tag(:nav, class: 'o-tabs') do
       content_tag(:ol, safe_join(tab_links))
     end
   end

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -1,5 +1,3 @@
-<div class="seperator"></div>
-
 <main id="content" role="main" class="metrics">
   <%= breadcrumbs %>
 

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -23,52 +23,58 @@
     </div>
   </header>
 
-  <%= tabs(current_page: page) do |tabs| %>
-    <% tabs.link_to tab_name('Departments', count: @metrics.departments_count), url_for(request.params.merge(group_by: Metrics::Group::Department)) if @metrics.has_departments? %>
-    <% tabs.link_to tab_name('Delivery organisations', count: @metrics.delivery_organisations_count), url_for(request.params.merge(group_by: Metrics::Group::DeliveryOrganisation)) if @metrics.has_delivery_organisations? %>
-    <% tabs.link_to tab_name('Services', count: @metrics.services_count), url_for(request.params.merge(group_by: Metrics::Group::Service)) if @metrics.has_services? %>
-  <% end %>
+  <div class="grid-row">
+    <div class="column-full">
 
-  <div class="grid-row o-filter-panel" data-behaviour="o-filter-panel">
-    <%= form_for @metrics, as: :filter, url: '', method: 'get', class: 'column-full filter-row' do |f| %>
-      <div class="m-sort-filter">
-        <%= f.label :order_by, 'Sort by' %>
-        <%= f.select :order_by, Metrics::OrderBy::ALL.map {|order| [order.name, order.identifier]}, {}, class: 'form-control' %>
-
-        <div class="m-sort-order">
-          <label><%= f.radio_button :order, Metrics::Order::Descending %> <span>High to Low</span></label>
-          <label><%= f.radio_button :order, Metrics::Order::Ascending %> <span>Low to High</span></label>
-          <!-- <a href="#">High to Low</a> | <a href="#">Low to High</a> -->
-        </div>
-
-        <button type="submit" class="a-apply-button">Apply</button>
-      </div>
-
-      <div class="m-search-filter hidden" data-behaviour="m-search-filter">
-        <label for="search-departments" class="visuallyhidden">Find department</label>
-        <input type="search" id="search-departments" class="a-search-input" placeholder="Find department">
-        <input class="a-search-button" type="button" value="Search">
-      </div>
-    <% end %>
-  </div>
-
-  <!--end of filter-->
-
-  <div class="o-metric-groups grid-row" data-behaviour="o-metric-groups">
-    <ul>
-
-      <% @metrics.metric_groups.each do |metric_group|  %>
-        <li class="m-metric-group" data-behaviour="m-metric-group<% if metric_group.collapsed? %> m-metric-group__collapsed<% end %>">
-          <div data-metric-group-expanded>
-            <%= render metric_group.entity, metric_group: metric_group  %>
-
-            <div class="m-metrics">
-              <%= render metric_group.metrics %>
-            </div>
-          </div>
-        </li>
+      <%= tabs(current_page: page) do |tabs| %>
+        <% tabs.link_to tab_name('Departments', count: @metrics.departments_count), url_for(request.params.merge(group_by: Metrics::Group::Department)) if @metrics.has_departments? %>
+        <% tabs.link_to tab_name('Delivery organisations', count: @metrics.delivery_organisations_count), url_for(request.params.merge(group_by: Metrics::Group::DeliveryOrganisation)) if @metrics.has_delivery_organisations? %>
+        <% tabs.link_to tab_name('Services', count: @metrics.services_count), url_for(request.params.merge(group_by: Metrics::Group::Service)) if @metrics.has_services? %>
       <% end %>
 
-    </ul>
-  </div>
+      <div class="o-filter-panel" data-behaviour="o-filter-panel">
+        <%= form_for @metrics, as: :filter, url: '', method: 'get', class: 'filter-row' do |f| %>
+          <div class="m-sort-filter">
+            <%= f.label :order_by, 'Sort by' %>
+            <%= f.select :order_by, Metrics::OrderBy::ALL.map {|order| [order.name, order.identifier]}, {}, class: 'form-control' %>
+
+            <div class="m-sort-order">
+              <label><%= f.radio_button :order, Metrics::Order::Descending %> <span>High to Low</span></label>
+              <label><%= f.radio_button :order, Metrics::Order::Ascending %> <span>Low to High</span></label>
+              <!-- <a href="#">High to Low</a> | <a href="#">Low to High</a> -->
+            </div>
+
+            <button type="submit" class="a-apply-button">Apply</button>
+          </div>
+
+          <div class="m-search-filter hidden" data-behaviour="m-search-filter">
+            <label for="search-departments" class="visuallyhidden">Find department</label>
+            <input type="search" id="search-departments" class="a-search-input" placeholder="Find department">
+            <input class="a-search-button" type="button" value="Search">
+          </div>
+        <% end %>
+      </div>
+
+      <!--end of filter-->
+
+      <div class="o-metric-groups" data-behaviour="o-metric-groups">
+        <ul>
+
+          <% @metrics.metric_groups.each do |metric_group|  %>
+            <li class="m-metric-group" data-behaviour="m-metric-group<% if metric_group.collapsed? %> m-metric-group__collapsed<% end %>">
+              <div data-metric-group-expanded>
+                <%= render metric_group.entity, metric_group: metric_group  %>
+
+                <div class="m-metrics">
+                  <%= render metric_group.metrics %>
+                </div>
+              </div>
+            </li>
+          <% end %>
+
+        </ul>
+      </div>
+
+    </div><!-- end of .column-full -->
+  </div><!-- end of .grid-row -->
 </main>

--- a/spec/helpers/tabs_helper_spec.rb
+++ b/spec/helpers/tabs_helper_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe TabsHelper, type: :helper do
         tabs.link_to 'Example 2', '/example2'
       end
 
-      expect(output).to have_selector('nav.o-tabs.grid-row ol')
-      expect(output).to have_selector('nav.o-tabs.grid-row ol li.m-tab-item a.m-tab-link[href="/example1"]', text: 'Example 1')
-      expect(output).to have_selector('nav.o-tabs.grid-row ol li.m-tab-item a.m-tab-link[href="/example2"]', text: 'Example 2')
+      expect(output).to have_selector('nav.o-tabs ol')
+      expect(output).to have_selector('nav.o-tabs ol li.m-tab-item a.m-tab-link[href="/example1"]', text: 'Example 1')
+      expect(output).to have_selector('nav.o-tabs ol li.m-tab-item a.m-tab-link[href="/example2"]', text: 'Example 2')
     end
 
     it 'marks the tab as selected if the path matches' do


### PR DESCRIPTION
Noticed some alignment issues where the filter panel seemed to be pushing out further than the text in the header column. 
Looks like the problem was a lot of `.grid-row`s that weren't being used to create a column layout. Diff is a bit hard to read, but essentially I've just wrapped the filter panel + metric group HTML in one big column so that it lines up with the header column.

`.grid-row` also adds a `-15px` right and left margin, so I've removed some CSS that looked like it was there just to counteract this.

| Before | After |
|--------|-------|
| ![screen shot 2017-08-01 at 11 25 30](https://user-images.githubusercontent.com/2454380/28821679-4c8b3d28-76ae-11e7-8369-7488f367acfa.png)  | ![screen shot 2017-08-01 at 11 24 35](https://user-images.githubusercontent.com/2454380/28821691-577f5444-76ae-11e7-81de-5bb9350c3e14.png) |