### PR TITLE
Add specific label to search box in filter panel

### DIFF
--- a/app/assets/javascripts/__tests__/search.test.js
+++ b/app/assets/javascripts/__tests__/search.test.js
@@ -11,8 +11,8 @@ describe('On the search page', function () {
   var $ = window.jQuery
   var searchFilterHTML =
     '<div class="m-search-filter hidden" data-behaviour="m-search-filter">' +
-      '<label for="search-departments" class="visuallyhidden">Find department</label>' +
-      '<input type="search" id="search-departments" class="a-search-input" placeholder="Find department">' +
+      '<label for="search-metrics">Find department</label>' +
+      '<input type="search" id="search-metrics" class="a-search-input" placeholder="Example: environment">' +
       '<input class="a-search-button" type="button" value="Search">' +
     '</div>'
 

--- a/app/assets/stylesheets/_metrics_filter_panel.scss
+++ b/app/assets/stylesheets/_metrics_filter_panel.scss
@@ -85,6 +85,7 @@
   select {
     order: 3;
     width: 100%;
+    display: block;
   }
 
   .a-apply-button {
@@ -112,8 +113,14 @@
 
     position: absolute;
     right: 0;
-    top: 0;
+    bottom: 0;
+
+    @include media(tablet) {
+      bottom: 22px;
+    }
   }
+
+
 }
 
 .o-filter-panel {

--- a/app/presenters/metrics_presenter.rb
+++ b/app/presenters/metrics_presenter.rb
@@ -11,6 +11,19 @@ class MetricsPresenter
 
   attr_reader :group_by, :order_by, :order
 
+  def group_by_screen_name
+    case group_by
+    when Metrics::Group::Department
+      'department'
+    when Metrics::Group::DeliveryOrganisation
+      'delivery organisation'
+    when Metrics::Group::Service
+      'service'
+    else
+      'by name'
+    end
+  end
+
   def organisation_name
     entity.name
   end
@@ -33,7 +46,7 @@ class MetricsPresenter
   def has_delivery_organisations?
     true
   end
-  
+
   def has_services?
     true
   end
@@ -45,7 +58,7 @@ class MetricsPresenter
       nil
     end
   end
-  
+
   def delivery_organisations_count
     if has_delivery_organisations?
       entity.delivery_organisations_count
@@ -53,7 +66,7 @@ class MetricsPresenter
       nil
     end
   end
-  
+
   def services_count
     if has_services?
       entity.services_count

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -48,8 +48,10 @@
           </div>
 
           <div class="m-search-filter hidden" data-behaviour="m-search-filter">
-            <label for="search-departments" class="visuallyhidden">Find department</label>
-            <input type="search" id="search-departments" class="a-search-input" placeholder="Find department">
+            <label for="search-metrics">
+              Find <%= @metrics.group_by_screen_name %>
+            </label>
+            <input type="search" id="search-metrics" class="a-search-input" placeholder="Example: environment">
             <input class="a-search-button" type="button" value="Search">
           </div>
         <% end %>


### PR DESCRIPTION
This is a prefigurative commit clearing the way for another one that will further rationalise the filter panel layout.

Printing a different label based on the level of hierarchy.
Seemed like a change that was easy to isolate.

Do we want some kind of test for this, or are we happy to let it go in as-is?

## screenshot after this change

The important part is where it says `Find service`-- it used to say "Find department".

![image](https://user-images.githubusercontent.com/2454380/28827057-3df7365c-76c4-11e7-8cea-5b88ff48a1b1.png)
