### PR TITLE
Bugfixes for search filter

### DIFF
--- a/app/assets/javascripts/__tests__/search.test.js
+++ b/app/assets/javascripts/__tests__/search.test.js
@@ -81,6 +81,13 @@ describe('On the search page', function () {
         expect($results.eq(1).hasClass('hidden')).toEqual(true)
       })
 
+      it('should filter the search results on search', function () {
+        $searchInput.val('revenue').trigger('search')
+
+        expect($results.eq(0).hasClass('hidden')).toEqual(false)
+        expect($results.eq(1).hasClass('hidden')).toEqual(true)
+      })
+
       it('should filter the search results ignoring spaces', function () {
         $searchInput.val('     revenue    ').trigger('keyup')
 

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -64,8 +64,8 @@
       fn(query)
     }
 
-    var _setKeyListenerOnInput = function (fn) {
-      $searchInput.on('keyup', function () {
+    var _setListenersOnInput = function (fn) {
+      $searchInput.on('keyup search', function () {
         _search(fn)
       })
     }
@@ -83,7 +83,7 @@
       $searchButton = $searchFilter.find('input[type="button"]')
 
       $searchFilter.removeClass('hidden')
-      _setKeyListenerOnInput(fn)
+      _setListenersOnInput(fn)
       _setClickListenerOnButton(fn)
     }
 

--- a/app/assets/stylesheets/_metrics_filter_panel.scss
+++ b/app/assets/stylesheets/_metrics_filter_panel.scss
@@ -116,7 +116,7 @@
     bottom: 0;
 
     @include media(tablet) {
-      bottom: 22px;
+      bottom: 0;
     }
   }
 
@@ -125,16 +125,11 @@
 
 .o-filter-panel {
   border-top: 1px solid $grey-2;
-  padding-top: 10px;
-  padding-bottom: 10px;
+  padding-top: 20px;
+  padding-bottom: 20px;
 
   form {
     padding: 0;
-  }
-
-  .m-sort-filter, .m-search-filter {
-    margin-top: 10px;
-    margin-bottom: 10px;
   }
 
   .a-apply-button {
@@ -144,7 +139,19 @@
 
 @media (min-width: 600px) {
   .o-filter-panel {
-    form { display: flex; }
+
+    form, .m-search-filter {
+      display: inline-block;
+      vertical-align: top;
+    }
+
+    form {
+      width: 66%;
+    }
+
+    .m-search-filter {
+      width: 33%;
+    }
   }
 
   .m-sort-filter {
@@ -157,9 +164,5 @@
 
   .m-sort-order {
     display: inline-block;
-  }
-
-  .m-search-filter {
-    flex-grow: 1;
   }
 }

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -46,15 +46,15 @@
 
             <button type="submit" class="a-apply-button">Apply</button>
           </div>
-
-          <div class="m-search-filter hidden" data-behaviour="m-search-filter">
-            <label for="search-metrics">
-              Find <%= @metrics.group_by_screen_name %>
-            </label>
-            <input type="search" id="search-metrics" class="a-search-input" placeholder="Example: environment">
-            <input class="a-search-button" type="button" value="Search">
-          </div>
         <% end %>
+
+        <div class="m-search-filter hidden" data-behaviour="m-search-filter">
+          <label for="search-metrics">
+            Find <%= @metrics.group_by_screen_name %>
+          </label>
+          <input type="search" id="search-metrics" class="a-search-input" placeholder="Example: environment">
+          <input class="a-search-button" type="button" value="Search">
+        </div>
       </div>
 
       <!--end of filter-->


### PR DESCRIPTION
This pull request kills two bugs:

- stops the form from submitting when a user presses "enter" while in the search filter
  - the search is entirely client-side so submitting the form from the search bar just refreshes the page and you lose your search terms
- resets the results after clicking the little 'x' that clears the search input field in some browsers


**Note**
I couldn't figure out how to write a test for the "enter" behaviour submitting/not submitting the form so at the moment there is no test for that behaviour. I'll ask within GDS if anyone has any recommendations.

## gifs 

| Before | After |
|--------|-------|
|  ![search-before](https://user-images.githubusercontent.com/2454380/28832764-48c29386-76d5-11e7-93b8-c55b5e583f4f.gif) | ![search-after](https://user-images.githubusercontent.com/2454380/28832771-4d936f34-76d5-11e7-8c4c-a70316b5d5fe.gif) |


