### PR TITLE
Remove .no-js class from body

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="no-js">
+<html lang="en">
   <head>
     <meta charset="utf-8">
 


### PR DESCRIPTION
`.no-js` is a class that expects modernizr to be used.
When you run modernizer, it fills up the `<body>` element with a bunch of conditional classnames so that you can write CSS selectors based on features that browsers support.
It also strips out the `.no-js` class, if it exists.

Since we're not using modernizr, the (potentially misleading) `.no-js` class isn't being removed.