### PR TITLE
HTML/CSS/Javascript general fixes (for Internet Explorers)

### DIFF
--- a/app/assets/javascripts/collapsed_metric_group.js
+++ b/app/assets/javascripts/collapsed_metric_group.js
@@ -22,9 +22,9 @@
       // information. Build the collapsed container with it's elements.
       var expandedContainer = $(element).find('[data-metric-group-expanded]')
 
-      var collapsedHeaderContainer = $('<div />', { class: 'm-metric-group-header' })
-      var metricItemDescriptionContainer = $('<div />', { class: 'm-metric-item-description' })
-      var openLinkContainer = $('<div />', { class: 'm-metric-group-open-toggle' })
+      var collapsedHeaderContainer = $('<div />', { 'class': 'm-metric-group-header' })
+      var metricItemDescriptionContainer = $('<div />', { 'class': 'm-metric-item-description' })
+      var openLinkContainer = $('<div />', { 'class': 'm-metric-group-open-toggle' })
       var collapsedContainer = $(
         '<div data-metric-group-collapsed>')
         .addClass('m-metric-group__collapsed')

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -60,7 +60,7 @@
     var $searchButton
 
     var _search = function (fn) {
-      var query = $searchInput.val().toLowerCase().trim()
+      var query = $.trim($searchInput.val().toLowerCase())
       fn(query)
     }
 

--- a/app/assets/stylesheets/__base.scss
+++ b/app/assets/stylesheets/__base.scss
@@ -1,6 +1,9 @@
 @import "product-page-example/source/stylesheets/core";
 @import "__assets";
 
+* { @include box-sizing(border-box); }
+main { display: block; }
+
 @import "time_period_selector";
 @import "metrics";
 @import "metric_group";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,9 +60,7 @@
       </div>
     </header>
 
-    <main role="main" id="main">
-      <%= yield %>
-    </main>
+    <%= yield %>
 
     <footer class="group js-footer" id="footer" role="contentinfo">
       <div class="footer-wrapper">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,8 @@
     <!--[if IE 8]><%= stylesheet_link_tag 'fonts-ie8', media: :all %><![endif]-->
     <!--[if gte IE 9]><!--><%= stylesheet_link_tag 'govuk_template/source/assets/stylesheets/fonts', media: :all %><!--<![endif]-->
 
+    <!--[if lt IE 9]><%= javascript_include_tag 'govuk_template/source/assets/javascripts/vendor/html5shiv-printshiv.js' %><![endif]-->
+
     <%= javascript_include_tag :application, async: true %>
   </head>
 

--- a/app/views/metrics/_time_period_selector.html.erb
+++ b/app/views/metrics/_time_period_selector.html.erb
@@ -1,4 +1,4 @@
 <div class="m-time-period-selector">
-  Data for time period from <time>1 Jan 2016</time> to <time>31 Dec 2016</time>
+  Data for time period from <time datetime="2016-01-01">1 Jan 2016</time> to <time datetime="2016-12-31">31 Dec 2016</time>
   <span><a href="#">Change dates</a></span>
 </div>

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -20,7 +20,7 @@
           <a href="#">Download data for this page (CSV 10KB)</a>
         </strong>
       </div>
-    </div>
+    </aside>
   </header>
 
   <div class="grid-row">

--- a/app/views/services/show.html.erb
+++ b/app/views/services/show.html.erb
@@ -45,7 +45,7 @@
 
     <div class="column-one-third">
       <h2 class="bold-medium">Visit the service</h2>
-      <p>See how it appears to users:
+      <p>See how it appears to users:</p>
         <ul class="list">
           <% if @service.start_page_url.present? %>
             <li><%= link_to 'Start page', @service.start_page_url %></li>
@@ -55,7 +55,6 @@
             <li><%= link_to 'Paper form', @service.paper_form_url %></li>
           <% end %>
         </ul>
-      </p>
     </div>
   </div>
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -7,5 +7,6 @@ Rails.application.config.assets.precompile = [
   'screen-old-ie',
   'product-image.png',
   'govuk_template/source/assets/stylesheets/fonts',
+  'govuk_template/source/assets/javascripts/vendor/html5shiv-printshiv.js',
   'govuk_template/source/assets/images/gov.uk_logotype_crown_invert_trans.png'
 ]


### PR DESCRIPTION
This pull request make a bunch of little changes so that our site looks/works better in more browsers.

- Adds a javascript shim for IE8 so that the side looks nice (which will only be loaded on IE8)
- Fixes some malformed HTML 
- Fixes javascript that didn't run on IE8
- CSS rule update fixes a broken layout on IE11, 10, 9, 8 etc

Shouldn't be anything too contentious in here.  The "data listing" page is still pretty ugly in IE8 in particular but mostly working in other IEs. Not going to make that a priority.

### Screenshots

| IE8 (before) | IE8 (after) |
|--------|-------|
| ![bs_win7_ie_8 0 1](https://user-images.githubusercontent.com/2454380/28925182-0443e43e-785c-11e7-9aee-6cffbbce3887.jpg) | ![bs_win7_ie_8 0](https://user-images.githubusercontent.com/2454380/28925166-fa4f2330-785b-11e7-9c8e-06d0c3fc2fee.jpg) |

| IE11 (before) | IE11 (after) |
|--------|-------|
| ![bs_win7_ie_11 0 1](https://user-images.githubusercontent.com/2454380/28925207-1a9ae66a-785c-11e7-965e-8d3456a32144.jpg)   |  ![bs_win7_ie_11 0](https://user-images.githubusercontent.com/2454380/28925226-231295fe-785c-11e7-8175-4ae371c6a09d.jpg)  |