### PR TITLE
Remove search button and flexbox rules for search filters

### DIFF
--- a/app/assets/javascripts/__tests__/search.test.js
+++ b/app/assets/javascripts/__tests__/search.test.js
@@ -13,7 +13,6 @@ describe('On the search page', function () {
     '<div class="m-search-filter hidden" data-behaviour="m-search-filter">' +
       '<label for="search-metrics">Find department</label>' +
       '<input type="search" id="search-metrics" class="a-search-input" placeholder="Example: environment">' +
-      '<input class="a-search-button" type="button" value="Search">' +
     '</div>'
 
   var SearchResultsHTML =
@@ -64,14 +63,6 @@ describe('On the search page', function () {
       afterEach(function () {
         // Drop everything from the page
         $(document.body).empty()
-      })
-
-      it('should filter the search results when clicked', function () {
-        $searchInput.val('revenue')
-        $searchFilter.find('input[type="button"]').trigger('click')
-
-        expect($results.eq(0).hasClass('hidden')).toEqual(false)
-        expect($results.eq(1).hasClass('hidden')).toEqual(true)
       })
 
       it('should filter the search results on keyup', function () {

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -57,7 +57,6 @@
   var SearchFilter = (function () {
     var $searchFilter
     var $searchInput
-    var $searchButton
 
     var _search = function (fn) {
       var query = $.trim($searchInput.val().toLowerCase())
@@ -70,21 +69,12 @@
       })
     }
 
-    var _setClickListenerOnButton = function (fn) {
-      $searchButton.on('click', function (e) {
-        _search(fn)
-        e.preventDefault()
-      })
-    }
-
     var init = function (fn) {
       $searchFilter = $('[data-behaviour="m-search-filter"]').first()
       $searchInput = $searchFilter.find('input[type="search"]')
-      $searchButton = $searchFilter.find('input[type="button"]')
 
       $searchFilter.removeClass('hidden')
       _setListenersOnInput(fn)
-      _setClickListenerOnButton(fn)
     }
 
     return {

--- a/app/assets/stylesheets/_metrics_filter_panel.scss
+++ b/app/assets/stylesheets/_metrics_filter_panel.scss
@@ -1,6 +1,5 @@
 .a-search-input {
-  @include core-16;
-  @include box-sizing(border-box);
+  @include core-19;
 
   height: 36px;
   padding: 6px;
@@ -21,22 +20,25 @@
   color: $white;
 }
 
-.m-sort-filter {
-  display: flex;
-  flex-wrap: wrap;
-  flex: 2 0 0;
+.m-sort-filter,
+.m-search-filter {
   width: 100%;
+  float: left;
 
-  /* this isn't super awesome */
-  margin-right: 60px;
-
-  label {
-    order: 1;
+  > * {
+    display: block;
   }
 
+  > label {
+    @include bold-19;
+  }
+}
+
+.m-sort-filter {
+  position: relative;
+  padding-bottom: $gutter-half;
+
   .m-sort-order {
-    order: 2;
-    flex-grow: 1;
     text-align: right;
 
     label {
@@ -62,90 +64,55 @@
   }
 
   select {
-    order: 3;
+    height: 36px;
     width: 100%;
-    display: block;
   }
 
-  .a-apply-button {
-    order: 4;
-  }
-}
-
-.m-search-filter {
-  display: block;
-  position: relative;
-  flex: 1 0 0;
-
-  .a-search-input {
-    margin-right: 0;
-    z-index: 0;
-
-    position: relative;
-<<<<<<< HEAD
-    width: 86%;
-    width: calc(100% - 36px);
-  }
-
-  .a-search-button {
-    margin-left: 0;
-    z-index: 1;
-
-    position: absolute;
-    right: 0;
-    bottom: 0;
-
-    @include media(tablet) {
-      bottom: 0;
+  @include media(mobile) {
+    .m-sort-order {
+      position: absolute;
+      top: 0;
+      right: 0;
     }
-=======
-    width: 100%;
->>>>>>> Remove search button
   }
 
-
-}
-
-.o-filter-panel {
-  border-top: 1px solid $grey-2;
-  padding-top: 20px;
-  padding-bottom: 20px;
-
-  form {
-    padding: 0;
-  }
-
-  .a-apply-button {
-    display: block;
-  }
-}
-
-@media (min-width: 600px) {
-  .o-filter-panel {
-
-    form, .m-search-filter {
+  @include media(tablet) {
+    .m-sort-order {
+      position: relative;
       display: inline-block;
-      vertical-align: top;
-    }
-
-    form {
-      width: 66%;
-    }
-
-    .m-search-filter {
-      width: 33%;
     }
   }
 
-  .m-sort-filter {
-    display: inline;
+  @include media(desktop) {
+    width: percentage(2/3);
+    padding-bottom: 0;
 
     select {
       width: auto;
     }
   }
+}
 
-  .m-sort-order {
-    display: inline-block;
+.m-search-filter {
+
+  .a-search-input {
+    margin-right: 0;
+    width: 100%;
+  }
+
+  @include media(desktop) {
+    width: percentage(1/3);
+    padding-left: $gutter-half;
+  }
+}
+
+.o-filter-panel {
+  @extend %contain-floats;
+  border-top: 1px solid $grey-2;
+  padding-top: $gutter-two-thirds;
+  padding-bottom: $gutter-two-thirds;
+
+  .a-apply-button {
+    display: block;
   }
 }

--- a/app/assets/stylesheets/_metrics_filter_panel.scss
+++ b/app/assets/stylesheets/_metrics_filter_panel.scss
@@ -6,33 +6,12 @@
   padding: 6px;
 
   border: 2px solid $black;
-  border-right: none;
   border-radius: 0;
   -webkit-appearance: none;
 
   &.focus,
   &:focus {
     outline-offset: -3px;
-  }
-}
-
-.a-search-button {
-  background-color: $black;
-  background-image: image-url('icon-search-2.png');
-  background-position: 50% 50%;
-  background-size: 20px 20px;
-  background-repeat: no-repeat;
-  border: 0;
-  width: 36px;
-  height: 36px;
-  overflow: hidden;
-  text-indent: -5000px;
-
-  @include border-radius(0);
-
-  &:hover {
-    cursor: pointer;
-    background-color: lighten($black, 30%);
   }
 }
 
@@ -103,6 +82,7 @@
     z-index: 0;
 
     position: relative;
+<<<<<<< HEAD
     width: 86%;
     width: calc(100% - 36px);
   }
@@ -118,6 +98,9 @@
     @include media(tablet) {
       bottom: 0;
     }
+=======
+    width: 100%;
+>>>>>>> Remove search button
   }
 
 

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -53,7 +53,6 @@
             Find <%= @metrics.group_by_screen_name %>
           </label>
           <input type="search" id="search-metrics" class="a-search-input" placeholder="Example: environment">
-          <input class="a-search-button" type="button" value="Search">
         </div>
       </div>
 


### PR DESCRIPTION
This pull request does a couple of things:

- removes the search button from the search filter
- fixes the CSS for the two inputs side by side

The search button isn't something we would actually click, which is why we are getting rid of it.
The flexbox layout doesn't work everywhere and we don't need it to do any fancy things for us, which is why I've gotten ride of that.

The screenshots and gifs assume the other two pull requests are in, so this will probably have to be rebased at some point.

### examples

| Chrome (before) | Chrome (after) |
|--------|-------|
| ![filters-before](https://user-images.githubusercontent.com/2454380/28926514-ecf13c38-785f-11e7-9790-588f6557ba30.gif)  | ![filters-after](https://user-images.githubusercontent.com/2454380/28926529-f64b139e-785f-11e7-9054-21253293f440.gif)   |

| IE10 (before) | IE10 (after) |
|--------|-------|
| ![bs_win7_ie_10 0 3](https://user-images.githubusercontent.com/2454380/28926568-1a96f02e-7860-11e7-82ed-913293eea093.jpg)   | ![bs_win7_ie_10 0 4](https://user-images.githubusercontent.com/2454380/28926575-21b1c29e-7860-11e7-81c9-23497a6aab5c.jpg)  |

<sub>`display: flex;` works in IE11, but not in 10, 9, 8, etc.</sub>