### PR TITLE
Add counter to search bar on metric groups page

### DIFF
--- a/app/assets/javascripts/__tests__/search.test.js
+++ b/app/assets/javascripts/__tests__/search.test.js
@@ -10,9 +10,10 @@ require('../search')
 describe('On the search page', function () {
   var $ = window.jQuery
   var searchFilterHTML =
-    '<div class="m-search-filter hidden" data-behaviour="m-search-filter">' +
+    '<div class="m-search-filter hidden" data-behaviour="m-search-filter" role="search">' +
       '<label for="search-metrics">Find department</label>' +
       '<input type="search" id="search-metrics" class="a-search-input" placeholder="Example: environment">' +
+      '<p id="search-counter" class="a-search-counter" data-behaviour="a-search-counter" class="visuallyhidden" aria-live="assertive" aria-atomic="true"></p>' +
     '</div>'
 
   var SearchResultsHTML =
@@ -29,6 +30,7 @@ describe('On the search page', function () {
 
   var $searchFilter
   var $searchInput
+  var $searchCounter
   var $results
 
   function _assertAllResults (opts) {
@@ -61,6 +63,7 @@ describe('On the search page', function () {
       // Add HTML to page
       $(document.body).append($(searchFilterHTML))
       $searchFilter = $('[data-behaviour="m-search-filter"]')
+      $searchCounter = $('[data-behaviour="a-search-counter"]')
     })
 
     afterEach(function () {
@@ -74,6 +77,13 @@ describe('On the search page', function () {
       expect($searchFilter.hasClass('hidden')).toEqual(false)
     })
 
+    it('should update the hidden search counter when the page loads', function () {
+      window.SearchFilter.init({}, 2)
+
+      expect($searchCounter.hasClass('visuallyhidden')).toEqual(true)
+      expect($searchCounter.text()).toEqual('2 total results')
+    })
+
     describe('when there are also search results', function () {
       beforeEach(function () {
         // Add search results HTML to page (it already has the search filter)
@@ -82,7 +92,10 @@ describe('On the search page', function () {
         $results = $('[data-behaviour^="m-metric-group"]')
 
         window.SearchResultsContainer.init()
-        window.SearchFilter.init(window.SearchResultsContainer.filter)
+        window.SearchFilter.init(
+          window.SearchResultsContainer.filter,
+          window.SearchResultsContainer.getResultsLength()
+        )
       })
 
       afterEach(function () {
@@ -116,6 +129,48 @@ describe('On the search page', function () {
 
         expect($results.eq(0).hasClass('hidden')).toEqual(false)
         expect($results.eq(1).hasClass('hidden')).toEqual(true)
+      })
+
+      describe('should update the search counter', function () {
+        function _filterResults (query) {
+          expect(window.SearchResultsContainer).not.toBe(undefined)
+          expect($searchInput.length).toBeGreaterThan(0)
+          $searchInput.val(query).trigger('search')
+        }
+
+        var assertAllResultsAreHidden = _assertAllResults(
+          {filterFn: _filterResults, isVisible: false})
+
+        var assertAllResultsAreVisible = _assertAllResults(
+          {filterFn: _filterResults, isVisible: true})
+
+        var assertOneResultIsVisible = _assertOneResult(
+          {filterFn: _filterResults, isVisible: false})
+
+        it('to be hidden when an empty query is given', function () {
+          assertAllResultsAreVisible('')
+          expect($searchCounter.hasClass('visuallyhidden')).toEqual(true)
+          expect($searchCounter.text()).toEqual('2 total results')
+        })
+
+        it('to be visible and indicating total results when a very general query is given', function () {
+          assertAllResultsAreVisible('r')
+          expect($searchCounter.hasClass('visuallyhidden')).toEqual(false)
+          expect($searchCounter.text()).toEqual('2 total results for “r”')
+        })
+
+        it('to be visible and indicating number of results when a matching substring query is given', function () {
+          assertOneResultIsVisible('reven')
+          expect($searchCounter.hasClass('visuallyhidden')).toEqual(false)
+          expect($searchCounter.text()).toEqual('1 result for “reven”')
+          expect($results.filter(':contains("HM Revenue")').hasClass('hidden')).toEqual(false)
+        })
+
+        it('to be visible and indicating no results when a non-matching query is given', function () {
+          assertAllResultsAreHidden('zzz')
+          expect($searchCounter.hasClass('visuallyhidden')).toEqual(false)
+          expect($searchCounter.text()).toEqual('No results for “zzz”')
+        })
       })
     })
   })

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,9 @@
 
   $(document).ready(function () {
     global.SearchResultsContainer.init()
-    global.SearchFilter.init(global.SearchResultsContainer.filter)
+    global.SearchFilter.init(
+      global.SearchResultsContainer.filter,
+      global.SearchResultsContainer.getResultsLength()
+    )
   })
 })(window)

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -81,12 +81,16 @@
       if (matches === total) {
         searchCounterHTML = '<strong>' + matches + '</strong> total results'
       } else if (matches === 1) {
-        searchCounterHTML = '<strong>' + matches + '</strong> result found'
+        searchCounterHTML = '<strong>' + matches + '</strong> result'
       } else if (matches === 0) {
         searchCounterHTML = 'No results'
       } else {
-        searchCounterHTML = '<strong>' + matches + '</strong> results found'
+        searchCounterHTML = '<strong>' + matches + '</strong> results'
       }
+
+      searchCounterHTML += query
+        ? ' for <span>&ldquo;' + query + '&rdquo;</span>'
+        : ''
 
       $searchCounter.html(searchCounterHTML)
     }

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -29,6 +29,7 @@
       /*
         Hide search results unless the query substring matches the title
        */
+      var matches = 0
 
       // if query is empty, remove all hidden classes and return length of results
       if (!query) {
@@ -42,39 +43,68 @@
 
         if (isMatch) {
           $(this).removeClass('hidden')
+          matches++
         } else {
           $(this).addClass('hidden')
         }
       })
+
+      return matches
     }
 
     return {
       init: init,
-      filter: filter
+      filter: filter,
+      getResultsLength: function () { return $results.length }
     }
   })()
 
   var SearchFilter = (function () {
     var $searchFilter
     var $searchInput
+    var $searchCounter
 
-    var _search = function (fn) {
+    var _search = function (searchFn, resultsLength) {
       var query = $.trim($searchInput.val().toLowerCase())
-      fn(query)
+      var matches = searchFn(query)
+      _updateCounter(matches, resultsLength, query)
     }
 
-    var _setListenersOnInput = function (fn) {
+    var _updateCounter = function (matches, total, query) {
+      var searchCounterHTML = ''
+
+      // show the counter if the search box is not empty
+      query
+        ? $searchCounter.removeClass('visuallyhidden')
+        : $searchCounter.addClass('visuallyhidden')
+
+      if (matches === total) {
+        searchCounterHTML = '<strong>' + matches + '</strong> total results'
+      } else if (matches === 1) {
+        searchCounterHTML = '<strong>' + matches + '</strong> result found'
+      } else if (matches === 0) {
+        searchCounterHTML = 'No results'
+      } else {
+        searchCounterHTML = '<strong>' + matches + '</strong> results found'
+      }
+
+      $searchCounter.html(searchCounterHTML)
+    }
+
+    var _setListenersOnInput = function (fn, resultsLength) {
       $searchInput.on('keyup search', function () {
-        _search(fn)
+        _search(fn, resultsLength)
       })
     }
 
-    var init = function (fn) {
+    var init = function (searchFn, resultsLength) {
       $searchFilter = $('[data-behaviour="m-search-filter"]').first()
       $searchInput = $searchFilter.find('input[type="search"]')
+      $searchCounter = $searchFilter.find('[data-behaviour="a-search-counter"]')
 
       $searchFilter.removeClass('hidden')
-      _setListenersOnInput(fn)
+      _setListenersOnInput(searchFn, resultsLength)
+      _updateCounter(resultsLength, resultsLength)
     }
 
     return {

--- a/app/assets/stylesheets/_metrics_filter_panel.scss
+++ b/app/assets/stylesheets/_metrics_filter_panel.scss
@@ -80,6 +80,7 @@
     .m-sort-order {
       position: relative;
       display: inline-block;
+      margin-top: 3px;
     }
   }
 
@@ -98,6 +99,11 @@
   .a-search-input {
     margin-right: 0;
     width: 100%;
+  }
+
+  .a-search-counter {
+    margin-top: 3px;
+    margin-bottom: 0;
   }
 
   @include media(desktop) {

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -48,18 +48,18 @@
           </div>
         <% end %>
 
-        <div class="m-search-filter hidden" data-behaviour="m-search-filter">
+        <div class="m-search-filter hidden" data-behaviour="m-search-filter" role="search">
           <label for="search-metrics">
             Find <%= @metrics.group_by_screen_name %>
           </label>
           <input type="search" id="search-metrics" class="a-search-input" placeholder="Example: environment">
-          <p class="a-search-counter" data-behaviour="a-search-counter" class="visuallyhidden">
+          <p id="search-counter" class="a-search-counter" data-behaviour="a-search-counter" class="visuallyhidden" aria-live="polite" aria-atomic="true"></p>
         </div>
       </div>
 
       <!--end of filter-->
 
-      <div class="o-metric-groups" data-behaviour="o-metric-groups">
+      <div class="o-metric-groups" data-behaviour="o-metric-groups" id="o-metric-groups">
         <ul>
           <li class="m-metric-group m-metric-group__totals" data-behaviour="m-metric-group<% if @metrics.collapsed? %> m-metric-group__collapsed<% end %>">
             <div data-metric-group-expanded>

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -53,6 +53,7 @@
             Find <%= @metrics.group_by_screen_name %>
           </label>
           <input type="search" id="search-metrics" class="a-search-input" placeholder="Example: environment">
+          <p class="a-search-counter" data-behaviour="a-search-counter" class="visuallyhidden">
         </div>
       </div>
 


### PR DESCRIPTION
This pull request adds in a search counter that appears when there is a search query and disappears when the search bar is empty.
Previously, there was no obvious way of knowing how many results were left other than scrolling down the page. 

Works on desktop and mobile.

## gifs

#### desktop
![search-sum](https://user-images.githubusercontent.com/2454380/29068788-25090618-7c30-11e7-8b6f-87cf720020d0.gif)

#### mobile
![search-sum-m](https://user-images.githubusercontent.com/2454380/29068705-d24fb138-7c2f-11e7-93dd-185b4e4c3acc.gif)



