### PR TITLE
Adds close link to expanded metric group

### DIFF
--- a/app/assets/javascripts/collapsed_metric_group.js
+++ b/app/assets/javascripts/collapsed_metric_group.js
@@ -1,7 +1,7 @@
 (function (global) {
   var $ = global.jQuery
 
-  $.fn.collapsedMetricGroup = function () {
+  $.fn.collapsibleMetricGroup = function () {
     // Determine which metric item has been sorted on. If we can't determine
     // it, then abort.
     var selectedMetricItem = $('[data-behaviour="o-filter-panel"] option:selected').val()
@@ -18,17 +18,18 @@
         return
       }
 
+      var collapsedHeaderContainer = $('<div />', { 'class': 'm-metric-group-header' })
+      var metricItemDescriptionContainer = $('<div />', { 'class': 'm-metric-item-description' })
+      var toggleLinkOpenContainer = $('<div />', { 'class': 'm-metric-group-open-toggle' })
+      var collapsedContainer = $(
+        '<div data-metric-group-collapsible>')
+        .addClass('m-metric-group__collapsible')
+        .append(collapsedHeaderContainer, metricItemDescriptionContainer, toggleLinkOpenContainer)
+
       // Find the "expanded" container, this has the full metric group
       // information. Build the collapsed container with it's elements.
       var expandedContainer = $(element).find('[data-metric-group-expanded]')
-
-      var collapsedHeaderContainer = $('<div />', { 'class': 'm-metric-group-header' })
-      var metricItemDescriptionContainer = $('<div />', { 'class': 'm-metric-item-description' })
-      var openLinkContainer = $('<div />', { 'class': 'm-metric-group-open-toggle' })
-      var collapsedContainer = $(
-        '<div data-metric-group-collapsed>')
-        .addClass('m-metric-group__collapsed')
-        .append(collapsedHeaderContainer, metricItemDescriptionContainer, openLinkContainer)
+      var toggleLinkCloseContainer = $('<div />', { 'class': 'm-metric-group-close-toggle' })
 
       // Populate the collapsed header container, with the header from the
       // expanded variant.
@@ -49,8 +50,20 @@
         collapsedContainer.hide()
         expandedContainer.show()
       })
-      openLinkContainer.append(openLink)
-      collapsedContainer.append(openLinkContainer)
+      toggleLinkOpenContainer.append(openLink)
+      collapsedContainer.append(toggleLinkOpenContainer)
+
+      // Create a closed link, and make its click behaviour hide
+      // the expanded variant.
+      var closeLink = $('<a href="#">Close</a>')
+      closeLink.on('click', function (e) {
+        e.preventDefault()
+
+        collapsedContainer.show()
+        expandedContainer.hide()
+      })
+      toggleLinkCloseContainer.append(closeLink)
+      expandedContainer.prepend(toggleLinkCloseContainer)
 
       // Add the collapsed container to the metric group, and hide the
       // expanded container.
@@ -60,6 +73,6 @@
   }
 
   $(document).ready(function () {
-    $('[data-behaviour~="m-metric-group__collapsed"]').collapsedMetricGroup()
+    $('[data-behaviour~="m-metric-group__collapsible"]').collapsibleMetricGroup()
   })
 })(window)

--- a/app/assets/stylesheets/_metric_group.scss
+++ b/app/assets/stylesheets/_metric_group.scss
@@ -13,7 +13,7 @@
   }
 }
 
-.m-metric-group__collapsed {
+.m-metric-group__collapsible {
   padding-top: 17px !important;
 
   .m-metric-group-header {
@@ -41,6 +41,13 @@
     width: 10%;
     text-align: right;
   }
+
+}
+
+.m-metric-group-close-toggle {
+  display: inline-block;
+  vertical-align: text-top;
+  float: right;
 }
 
 .m-metric-group__totals {

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -59,7 +59,7 @@
 
       <div class="o-metric-groups" data-behaviour="o-metric-groups" id="o-metric-groups">
         <ul>
-          <li class="m-metric-group m-metric-group__totals" data-behaviour="m-metric-group<% if @metrics.collapsed? %> m-metric-group__collapsed<% end %>">
+          <li class="m-metric-group m-metric-group__totals" data-behaviour="m-metric-group<% if @metrics.collapsed? %> m-metric-group__collapsible<% end %>">
             <div data-metric-group-expanded>
               <div class="m-metric-group-header">
                 <h2 class="bold-medium">Total for <%= @metrics.organisation_name %></h2>
@@ -72,7 +72,7 @@
           </li>
 
           <% @metrics.metric_groups.each do |metric_group|  %>
-            <li class="m-metric-group" data-behaviour="m-metric-group<% if metric_group.collapsed? %> m-metric-group__collapsed<% end %>">
+            <li class="m-metric-group" data-behaviour="m-metric-group<% if metric_group.collapsed? %> m-metric-group__collapsible<% end %>">
               <div data-metric-group-expanded>
                 <%= render metric_group.entity, metric_group: metric_group  %>
 

--- a/spec/features/viewing_metrics_spec.rb
+++ b/spec/features/viewing_metrics_spec.rb
@@ -61,10 +61,10 @@ RSpec.feature 'viewing metrics', type: :feature do
       visit government_metrics_path(group_by: Metrics::Group::Department)
 
       expect(page).to have_selector('.m-metric-group', count: 8)
-      expect(page).to have_selector('.m-metric-group[data-behaviour~="m-metric-group__collapsed"]', count: 0)
+      expect(page).to have_selector('.m-metric-group[data-behaviour~="m-metric-group__collapsible"]', count: 0)
 
       select 'transactions received', from: 'Sort by'
-      expect(page).to have_selector('.m-metric-group[data-behaviour~="m-metric-group__collapsed"]', count: 8)
+      expect(page).to have_selector('.m-metric-group[data-behaviour~="m-metric-group__collapsible"]', count: 8)
     end
   end
 


### PR DESCRIPTION
This PR changes the behaviour for collapsed metric groups, renaming them
collapsible metric groups (so it sounds more like a behaviour than a
state) at the same time.

A close link is added to the ```expandedContainer``` which will do the
inverse of the open link which was added to the ```collapsedContainer```