### PR TITLE
Prevent errors when a service doesn't have a delivery organisation.

### DIFF
--- a/app/api/government_service_data_api/delivery_organisation.rb
+++ b/app/api/government_service_data_api/delivery_organisation.rb
@@ -1,5 +1,7 @@
 GovernmentServiceDataAPI::DeliveryOrganisation = Struct.new(:key, :name, :services_count, :department) do
   def self.build(response)
+    return nil if response.nil?
+
     department = GovernmentServiceDataAPI::Department.build(response['department'])
 
     new(

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -9,7 +9,11 @@ class ServicesController < ApplicationController
 
     page.breadcrumbs << Page::Crumb.new('UK Government', government_metrics_path)
     page.breadcrumbs << Page::Crumb.new(@service.department.name, department_metrics_path(department_id: @service.department.key))
-    page.breadcrumbs << Page::Crumb.new(@service.delivery_organisation.name, delivery_organisation_metrics_path(delivery_organisation_id: @service.delivery_organisation.key))
+
+    if @service.delivery_organisation
+      page.breadcrumbs << Page::Crumb.new(@service.delivery_organisation.name, delivery_organisation_metrics_path(delivery_organisation_id: @service.delivery_organisation.key))
+    end
+
     page.breadcrumbs << Page::Crumb.new(@service.name)
   end
 end

--- a/spec/api/government_service_data_api/client_spec.rb
+++ b/spec/api/government_service_data_api/client_spec.rb
@@ -74,6 +74,12 @@ RSpec.describe GovernmentServiceDataAPI::Client, type: :api do
       expect(department.delivery_organisations_count).to eq(2)
       expect(department.services_count).to eq(9)
     end
+
+    it 'parses a service without a delivery organisation', cassette: 'service-no-delivery-organisation-ok' do
+      service = client.service('19')
+
+      expect(service.delivery_organisation).to be_nil
+    end
   end
 
   describe '#metrics' do

--- a/spec/controllers/service_controller_spec.rb
+++ b/spec/controllers/service_controller_spec.rb
@@ -30,5 +30,17 @@ RSpec.describe ServicesController, type: :controller do
         ['The Greatest Service in the World', nil],
       ])
     end
+
+    it 'sets the breadcrumbs without a delivery organisation' do
+      allow(service).to receive(:delivery_organisation) { nil }
+
+      get :show, params: { id: '2' }
+
+      expect(page.breadcrumbs.map { |crumb| [crumb.name, crumb.url] }).to eq([
+        ['UK Government', government_metrics_path],
+        ['Department of Services', department_metrics_path(department_id: '001')],
+        ['The Greatest Service in the World', nil],
+      ])
+    end
   end
 end

--- a/spec/fixtures/vcr/service-no-delivery-organisation-ok.yml
+++ b/spec/fixtures/vcr/service-no-delivery-organisation-ok.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://gsd-api.dev/v1/data/services/19
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic dGVzdDp0ZXN0
+      User-Agent:
+      - Faraday v0.12.1
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      content-type:
+      - application/json; charset=utf-8
+      etag:
+      - W/"7f6553b41cf72db5990ecb42cbf77f10"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - ceea9b92-f45a-458d-9b70-2c217998a5d6
+      x-runtime:
+      - '0.314203'
+      date:
+      - Wed, 16 Aug 2017 10:11:41 GMT
+      connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJ0eXBlIjoic2VydmljZSIsIm5hdHVyYWxfa2V5IjoiMTkiLCJuYW1lIjoiU3RhdGUgcGVuc2lvbjogZXhpc3RpbmcgY2xhaW1zIiwiaG9zdG5hbWUiOiJzdGF0ZS1wZW5zaW9uLWV4aXNpdGluZy1jbGFpbXMiLCJwdXJwb3NlIjoiV2h5IHRoZSBzZXJ2aWNlIHdhcyBidWlsdCwgaXRzIHBvbGljeSBvYmplY3RpdmVzIGFuZCB0aGUgdXNlciBuZWVkIGl0IG1lZXRzLiIsImhvd19pdF93b3JrcyI6IlRoZSBwcm9jZXNzZXMgYW5kIGJhY2stb2ZmaWNlIG9wZXJhdGlvbnMgdGhhdCBhbGxvdyB0aGUgc2VydmljZSB0byBvcGVyYXRlLiIsInR5cGljYWxfdXNlcnMiOiJFYWNoIG9mIHRoZSBzZXJ2aWNl4oCZcyBrZXkgdXNlciBncm91cHMgd2l0aCB0aGVpciByZXNwZWN0aXZlIGRlbW9ncmFwaGljLCBnZW9ncmFwaGljIGRpc3RyaWJ1dGlvbiBhbmQgb3RoZXIgcmVsZXZhbnQgZGV0YWlscy4iLCJmcmVxdWVuY3lfdXNlZCI6Ik9uIGF2ZXJhZ2UsIGhvdyBvZnRlbiBlYWNoIG9mIHRoZSBrZXkgdXNlciBncm91cHMgdXNlcyB0aGUgc2VydmljZS4iLCJkdXJhdGlvbl91bnRpbF9vdXRjb21lIjoiVGhlIGF2ZXJhZ2UgYW1vdW50IG9mIHRpbWUgZm9yIGVhY2ggb2YgdGhlIGtleSB1c2VyIGdyb3VwcyB0aGF0IGl0IHRha2VzIGZvciBhIHJlY2VpdmVkIHRyYW5zYWN0aW9uIHRvIGVuZCBpbiBhbiBvdXRjb21lLiIsInN0YXJ0X3BhZ2VfdXJsIjoiaHR0cHM6Ly9leGFtcGxlLmNvbSIsInBhcGVyX2Zvcm1fdXJsIjoiaHR0cHM6Ly9leGFtcGxlLmNvbSIsImRlcGFydG1lbnQiOnsidHlwZSI6ImRlcGFydG1lbnQiLCJuYXR1cmFsX2tleSI6IkQwMDA0IiwibmFtZSI6IkhNIFJldmVudWUgXHUwMDI2IEN1c3RvbXMiLCJ3ZWJzaXRlIjoiaHR0cDovL2V4YW1wbGUuY29tL2htLXJldmVudWUtYW5kLWN1c3RvbXMiLCJkZWxpdmVyeV9vcmdhbmlzYXRpb25zX2NvdW50IjowLCJzZXJ2aWNlc19jb3VudCI6NX0sImRlbGl2ZXJ5X29yZ2FuaXNhdGlvbiI6bnVsbH0=
+    http_version: 
+  recorded_at: Wed, 16 Aug 2017 10:11:41 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
It's feasible for a service to not have a delivery organisation. In this
case we shouldn't error. This fixes parsing the API response to handle
nil, and also displaying the breadcrumbs on the service's show page.