### PR TITLE
Updates the travis setup to also cache node modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 dist: trusty
 language: ruby
 sudo: true
-cache: bundler
+cache:
+  bundler: true
+  directories:
+  - node_modules 
 
 env:
   global:


### PR DESCRIPTION
Adds node_modules to the list of things to cache on travis.  This should
significantly speed up the build time.

```npm install``` goes from 25s->2s each run.