### PR TITLE
Sortable Metric Group Totals

### DIFF
--- a/app/api/government_service_data_api/government.rb
+++ b/app/api/government_service_data_api/government.rb
@@ -6,4 +6,8 @@ GovernmentServiceDataAPI::Government = Struct.new(:departments_count, :delivery_
       response['services_count'],
     )
   end
+
+  def name
+    'UK government'
+  end
 end

--- a/app/api/government_service_data_api/metrics.rb
+++ b/app/api/government_service_data_api/metrics.rb
@@ -1,19 +1,19 @@
 class GovernmentServiceDataAPI::Metrics
   def self.build(response, entity:)
-    metrics = GovernmentServiceDataAPI::MetricGroup.new(entity, response['metrics'].index_by { |metric| metric['type'] })
+    totals = GovernmentServiceDataAPI::MetricGroup.new(entity, response['metrics'].index_by { |metric| metric['type'] })
 
     metric_groups = response['metric_groups'].map do |metric_group|
       GovernmentServiceDataAPI::MetricGroup.build(metric_group)
     end
 
-    new(entity, metrics, metric_groups)
+    new(entity, totals, metric_groups)
   end
 
-  def initialize(entity, metrics, metric_groups)
+  def initialize(entity, totals, metric_groups)
     @entity = entity
-    @metrics = metrics
+    @totals = totals
     @metric_groups = metric_groups
   end
 
-  attr_reader :entity, :metrics, :metric_groups
+  attr_reader :entity, :totals, :metric_groups
 end

--- a/app/presenters/metric_group_presenter.rb
+++ b/app/presenters/metric_group_presenter.rb
@@ -11,6 +11,22 @@ class MetricGroupPresenter
     end
   end
 
+  class Total < self
+    module EntityToPartialPath
+      def to_partial_path
+        'metric_groups/header/total'
+      end
+    end
+
+    def entity
+      @entity ||= @metric_group.entity.extend(EntityToPartialPath)
+    end
+
+    def total?
+      true
+    end
+  end
+
   def initialize(metric_group, collapsed: false)
     @metric_group = metric_group
     @collapsed = collapsed
@@ -41,5 +57,9 @@ class MetricGroupPresenter
 
   def collapsed?
     @collapsed ? true : false
+  end
+
+  def total?
+    false
   end
 end

--- a/app/presenters/metric_group_presenter.rb
+++ b/app/presenters/metric_group_presenter.rb
@@ -11,7 +11,7 @@ class MetricGroupPresenter
     end
   end
 
-  class Total < self
+  class Totals < self
     module EntityToPartialPath
       def to_partial_path
         'metric_groups/header/total'
@@ -22,7 +22,7 @@ class MetricGroupPresenter
       @entity ||= @metric_group.entity.extend(EntityToPartialPath)
     end
 
-    def total?
+    def totals?
       true
     end
   end
@@ -59,7 +59,7 @@ class MetricGroupPresenter
     @collapsed ? true : false
   end
 
-  def total?
+  def totals?
     false
   end
 end

--- a/app/presenters/metrics_presenter.rb
+++ b/app/presenters/metrics_presenter.rb
@@ -32,9 +32,17 @@ class MetricsPresenter
     @metric_groups ||= begin
       metric_groups = data.metric_groups
                         .map { |metric_group| MetricGroupPresenter.new(metric_group, collapsed: collapsed?) }
-                        .unshift(MetricGroupPresenter::Total.new(data.metrics, collapsed: collapsed?))
                         .sort_by(&sorter)
       metric_groups.reverse! if order == Metrics::Order::Descending
+
+      if order_by == Metrics::OrderBy::Name.identifier
+        metric_groups.unshift(totals_metric_group_presenter)
+      elsif order == Metrics::Order::Ascending
+        metric_groups.push(totals_metric_group_presenter)
+      elsif order == Metrics::Order::Descending
+        metric_groups.unshift(totals_metric_group_presenter)
+      end
+
       metric_groups
     end
   end
@@ -79,5 +87,9 @@ private
 
   def data
     @data ||= client.metrics(entity, group_by: group_by)
+  end
+
+  def totals_metric_group_presenter
+    @totals_metric_group_presenter ||= MetricGroupPresenter::Totals.new(data.totals, collapsed: collapsed?)
   end
 end

--- a/app/presenters/metrics_presenter.rb
+++ b/app/presenters/metrics_presenter.rb
@@ -28,14 +28,11 @@ class MetricsPresenter
     entity.name
   end
 
-  def organisation_metrics
-    MetricGroupPresenter.new(data.metrics, collapsed: collapsed?).metrics
-  end
-
   def metric_groups
     @metric_groups ||= begin
       metric_groups = data.metric_groups
                         .map { |metric_group| MetricGroupPresenter.new(metric_group, collapsed: collapsed?) }
+                        .unshift(MetricGroupPresenter::Total.new(data.metrics, collapsed: collapsed?))
                         .sort_by(&sorter)
       metric_groups.reverse! if order == Metrics::Order::Descending
       metric_groups
@@ -79,7 +76,6 @@ class MetricsPresenter
 private
 
   attr_reader :client, :entity, :sorter
-
 
   def data
     @data ||= client.metrics(entity, group_by: group_by)

--- a/app/views/metric_groups/header/_total.html.erb
+++ b/app/views/metric_groups/header/_total.html.erb
@@ -1,0 +1,3 @@
+<div class="m-metric-group-header">
+  <h2 class="bold-medium">Total for <%= metric_group.name %></h2>
+</div>

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -59,20 +59,8 @@
 
       <div class="o-metric-groups" data-behaviour="o-metric-groups" id="o-metric-groups">
         <ul>
-          <li class="m-metric-group m-metric-group__totals" data-behaviour="m-metric-group<% if @metrics.collapsed? %> m-metric-group__collapsible<% end %>">
-            <div data-metric-group-expanded>
-              <div class="m-metric-group-header">
-                <h2 class="bold-medium">Total for <%= @metrics.organisation_name %></h2>
-              </div>
-
-              <div class="m-metrics">
-                <%= render @metrics.organisation_metrics %>
-              </div>
-            </div>
-          </li>
-
           <% @metrics.metric_groups.each do |metric_group|  %>
-            <li class="m-metric-group" data-behaviour="m-metric-group<% if metric_group.collapsed? %> m-metric-group__collapsible<% end %>">
+            <li class="m-metric-group<% if metric_group.total? %> m-metric-group__totals<% end %>" data-behaviour="m-metric-group<% if metric_group.collapsed? %> m-metric-group__collapsible<% end %>">
               <div data-metric-group-expanded>
                 <%= render metric_group.entity, metric_group: metric_group  %>
 

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -60,7 +60,7 @@
       <div class="o-metric-groups" data-behaviour="o-metric-groups" id="o-metric-groups">
         <ul>
           <% @metrics.metric_groups.each do |metric_group|  %>
-            <li class="m-metric-group<% if metric_group.total? %> m-metric-group__totals<% end %>" data-behaviour="m-metric-group<% if metric_group.collapsed? %> m-metric-group__collapsible<% end %>">
+            <li class="m-metric-group<% if metric_group.totals? %> m-metric-group__totals<% end %>" data-behaviour="m-metric-group<% if metric_group.collapsed? %> m-metric-group__collapsible<% end %>">
               <div data-metric-group-expanded>
                 <%= render metric_group.entity, metric_group: metric_group  %>
 

--- a/spec/features/viewing_metrics_spec.rb
+++ b/spec/features/viewing_metrics_spec.rb
@@ -25,7 +25,6 @@ RSpec.feature 'viewing metrics', type: :feature do
         all('a', text: /\AOpen\z/).each(&:click) if javascript_enabled
 
         expect(metric_groups(:name, :transactions_received_total)).to eq([
-          ['Total for UK government', '746067381'],
           ['HM Revenue & Customs', '0'],
           ['Department for Business, Energy & Industrial Strategy', '0'],
           ['Department for Environment Food & Rural Affairs', '3000039'],
@@ -33,6 +32,7 @@ RSpec.feature 'viewing metrics', type: :feature do
           ['Department of Health', '18132669'],
           ['Department for Transport', '118679511'],
           ['Ministry of Justice', '593254687'],
+          ['Total for UK government', '746067381'],
         ])
 
         if javascript_enabled

--- a/spec/presenters/metric_group_presenter_spec.rb
+++ b/spec/presenters/metric_group_presenter_spec.rb
@@ -5,7 +5,19 @@ RSpec.describe MetricGroupPresenter, type: :presenter do
   let(:metric) { double('metric') }
   let(:metrics) { [metric] }
   let(:metric_group) { instance_double(GovernmentServiceDataAPI::MetricGroup, entity: entity, metrics: metrics) }
-  subject(:presenter) { MetricGroupPresenter.new(metric_group) }
+  subject(:presenter) { described_class.new(metric_group) }
+
+  describe MetricGroupPresenter::Totals do
+    describe '#entity' do
+      it 'returns a partial path to display the metric group header' do
+        expect(presenter.entity.to_partial_path).to eq('metric_groups/header/total')
+      end
+    end
+
+    describe '#totals?' do
+      it { expect(presenter.totals?).to be_truthy }
+    end
+  end
 
   describe '#entity' do
     it 'returns a partial path to display the metric group header' do
@@ -59,5 +71,9 @@ RSpec.describe MetricGroupPresenter, type: :presenter do
       presenter = MetricGroupPresenter.new(metric_group, collapsed: true)
       expect(presenter).to be_collapsed
     end
+  end
+
+  describe '#totals?' do
+    it { expect(presenter.totals?).to be_falsey }
   end
 end


### PR DESCRIPTION
When ordering by a metric item, we insert the total metric group, at the
beginning or end of the list depending on whether 'High to Low' or 'Low
to High' was selected.

There's a special case, when name is the selected sort order. We never
want to see the total ordered by name, so always prepend it – so it's
displayed at the top.