### PR TITLE
Fixes overlap of title and completeness badge.

### DIFF
--- a/app/assets/stylesheets/_metric_group.scss
+++ b/app/assets/stylesheets/_metric_group.scss
@@ -100,6 +100,10 @@
   &:last-child {
     margin-bottom: 0;
   }
+
+  h2 {
+    width: 75%;
+  }
 }
 
 .m-metric-group__collapsed {

--- a/app/assets/stylesheets/_metric_group.scss
+++ b/app/assets/stylesheets/_metric_group.scss
@@ -106,6 +106,15 @@
   }
 }
 
+@media (max-width: 480px) {
+  .m-metric-group__expanded {
+    h2 {
+      margin-top: 20px;
+      width: 100%;
+    }
+  }
+}
+
 .m-metric-group__collapsed {
   border: 1px solid #BFC1C3;
   margin-top: -1px;


### PR DESCRIPTION
Makes sure when the metric group is expanded that the service title
doesn't try and use 100% of the width.

At phone screen sizes it introduces a margin and resets the h2 width so that it doesn't overlap with the completeness value.

Fixes #56 (for desktop and mobile)