### PR TITLE
Allow HTML in Metric Guidance

### DIFF
--- a/app/assets/javascripts/metric_guidance.js
+++ b/app/assets/javascripts/metric_guidance.js
@@ -12,8 +12,8 @@
 
       var metricGuidance = container.find('[data-metric-guidance]')
       if (metricGuidance.length === 0) {
-        var descriptionElement = $('<p />', {'class': 'a-metric-guidance', 'data-metric-guidance': 'data-metric-guidance'})
-        descriptionElement.text(guidance)
+        var descriptionElement = $('<div />', {'class': 'a-metric-guidance', 'data-metric-guidance': 'data-metric-guidance'})
+        descriptionElement.html(guidance)
 
         container.append(descriptionElement)
         metricGuidance = descriptionElement

--- a/app/helpers/metric_item_helper.rb
+++ b/app/helpers/metric_item_helper.rb
@@ -8,7 +8,7 @@ module MetricItemHelper
     item = MetricItem.new(self, metric_value)
     content = capture { yield(item) } || ''
 
-    guidance = translate("metric_guidance.#{identifier}.description") if guidance?(identifier)
+    guidance = translate(:description_html, default: :description, scope: ['metric_guidance', identifier]) if guidance?(identifier)
 
     html[:data] ||= {}
     html[:data].merge!('metric-item-identifier' => identifier, 'metric-item-description' => item.description.try(:strip), 'metric-item-guidance' => guidance)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,8 +6,12 @@ en:
 
     'transactions-ending-in-outcome':
       name: transactions ending in an outcome
-      description: These numbers tell you how many transactions the service processed, and how well these transaction met users' needs.
+      description: These numbers tell you how many transactions the service processed, and how well these transactions met users' needs.
 
     'calls-received':
       name: calls received
       description: These numbers tell you how much the call centre was used, and why.
+      
+      If the total number of calls is high then the number of transactions, that’s an indication that effort is high compared to output.
+      
+If the proportion of users calling to chase progress is high, this might mean that the service isn’t processing transactions as quickly as it should. A high proportion of calls to get more information could indicate that the information available online is incomplete or unclear.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,8 +10,7 @@ en:
 
     'calls-received':
       name: calls received
-      description: These numbers tell you how much the call centre was used, and why.
-      
-      If the total number of calls is high then the number of transactions, that’s an indication that effort is high compared to output.
-      
-If the proportion of users calling to chase progress is high, this might mean that the service isn’t processing transactions as quickly as it should. A high proportion of calls to get more information could indicate that the information available online is incomplete or unclear.
+      description_html:
+        <p>These numbers tell you how much the call centre was used, and why.</p>
+        <p>If the total number of calls is higher than the number of transactions, that’s an indication that effort is high compared to output.</p>
+        <p>If the proportion of users calling to chase progress is high, this might mean that the service isn’t processing transactions as quickly as it should. A high proportion of calls to get more information could indicate that the information available online is incomplete or unclear.</p>


### PR DESCRIPTION
To support paragraphs in metric guidance, per #60, we need to support HTML.

This changes the metric item helper to prefer a `description_html` key, if it exists. It also changes to use `html` instead of `text` when toggling in the frontend. 