### PR TITLE
Fix tag manager content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem 'jquery-rails'
 
 gem 'faraday'
 gem 'faraday_middleware'
-gem 'google-tag-manager-rails'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,8 +71,6 @@ GEM
     ffi (1.9.18)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
-    google-tag-manager-rails (0.1.3)
-      rails (>= 3.0.0)
     govuk-lint (2.1.0)
       rubocop (~> 0.43.0)
       scss_lint
@@ -230,7 +228,6 @@ DEPENDENCIES
   dotenv-rails
   faraday
   faraday_middleware
-  google-tag-manager-rails
   govuk-lint
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/helpers/google_tag_manager_helper.rb
+++ b/app/helpers/google_tag_manager_helper.rb
@@ -1,0 +1,26 @@
+module GoogleTagManagerHelper
+  def tag_manager_js
+    return '' if !tag_manager_code
+    %{
+      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','#{tag_manager_code}');</script>
+     }.strip.html_safe
+  end
+
+  def tag_manager_nojs
+    return '' if !tag_manager_code
+    %{
+      <noscript><iframe src="//www.googletagmanager.com/ns.html?id=#{tag_manager_code}"
+      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+     }.strip.html_safe
+  end
+
+private
+
+  def tag_manager_code
+    ENV['TAG_MANAGER_ID']
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <%= tag_manager_js -%>
     <meta charset="utf-8">
 
     <title><%= page.title %></title>
@@ -20,7 +21,7 @@
   </head>
 
   <body>
-    <%= google_tag_manager %>
+    <%= tag_manager_nojs -%>
     <a href="#main" class="skip-link">Skip to main content</a>
 
     <header class="header<% unless page.display_header_border %> header--without-border<% end %>">

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,6 +26,4 @@ Rails.application.configure do
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
-
-  GoogleTagManager.gtm_id = ENV['TAG_MANAGER_ID']
 end


### PR DESCRIPTION
Put the JS at the start of the head (as recommended by Google) and the
noscript tag at the start of the body.