### PR TITLE
Makes the default date display, same as API

### DIFF
--- a/app/helpers/time_period_helper.rb
+++ b/app/helpers/time_period_helper.rb
@@ -1,0 +1,20 @@
+module TimePeriodHelper
+  DEFAULT_TIME_PERIOD_DURATION = 12.months
+  DEFAULT_TIME_PERIOD_LAG = 2.months
+
+  def start_date_string
+    start_date.strftime "%e %b %Y"
+  end
+
+  def end_date_string
+    end_date.strftime "%e %b %Y"
+  end
+
+  def start_date
+    (end_date - DEFAULT_TIME_PERIOD_DURATION + 1.day)
+  end
+
+  def end_date
+    (Date.today - DEFAULT_TIME_PERIOD_LAG).end_of_month
+  end
+end

--- a/app/views/metrics/_time_period_selector.html.erb
+++ b/app/views/metrics/_time_period_selector.html.erb
@@ -1,3 +1,3 @@
 <div class="m-time-period-selector">
-  Data for time period from <time datetime="2017-01-01">1 Jan 2017</time> to <time datetime="2017-06-30">30 Jun 2017</time>
+  Data for time period from <time datetime="<%= start_date %>"><%= start_date_string %></time> to <time datetime="<%= end_date %>"><%= end_date_string %></time>
 </div>


### PR DESCRIPTION
Rather than hard-coding the date range, we will use the same one we use
in the API so that it matches up.