### PR TITLE
Fix showing Not provided when trxn_rx total not provided

### DIFF
--- a/app/api/government_service_data_api/transactions_received_metric.rb
+++ b/app/api/government_service_data_api/transactions_received_metric.rb
@@ -35,7 +35,7 @@ class GovernmentServiceDataAPI::TransactionsReceivedMetric
 
   def not_provided?
     [
-      @total, @online, @phone, @paper, @face_to_face, @other
+      @online, @phone, @paper, @face_to_face, @other
     ].all? { |item| item == NOT_PROVIDED }
   end
 


### PR DESCRIPTION
Although we ask for trxn_rx total, we don't use it, instead summing the
other values.  This change ignores @total when determining whether the
trxn_rx is actually not provided.