### PR TITLE
Load download icon with sass helper

### DIFF
--- a/app/assets/stylesheets/_metrics.scss
+++ b/app/assets/stylesheets/_metrics.scss
@@ -32,7 +32,7 @@ main {
 }
 
 .icon-file-download {
-  background-image: url(/assets/icon-file-download-2x.png);
+  background-image: url(image-path('icon-file-download-2x.png'));
   background-size: 100%;
   width: 24px;
   height: 31px;


### PR DESCRIPTION
Use a sass helper (image-path) to point at the download icon rather than
use a hard-coded path