### PR TITLE
Remove services from collapsed list when no sort value

### DIFF
--- a/app/helpers/metric_item_helper.rb
+++ b/app/helpers/metric_item_helper.rb
@@ -1,6 +1,5 @@
 module MetricItemHelper
   include GovernmentServiceDataAPI::MetricStatus
-  #include Metrics::Items
 
   def metric_item(metric_item, metric_value, sampled: false, html: {})
     return if metric_value == NOT_APPLICABLE

--- a/app/helpers/metric_item_helper.rb
+++ b/app/helpers/metric_item_helper.rb
@@ -1,22 +1,22 @@
 module MetricItemHelper
   include GovernmentServiceDataAPI::MetricStatus
-  include Metrics::Items
+  #include Metrics::Items
 
-  def metric_item(identifier, metric_value, sampled: false, html: {})
+  def metric_item(metric_item, metric_value, sampled: false, html: {})
     return if metric_value == NOT_APPLICABLE
 
-    item = MetricItem.new(self, metric_value)
+    item = MetricItemContent.new(self, metric_value)
     content = capture { yield(item) } || ''
 
-    guidance = translate(:description_html, default: :description, scope: ['metric_guidance', identifier]) if guidance?(identifier)
+    guidance = translate(:description_html, default: :description, scope: ['metric_guidance', metric_item.identifier]) if guidance?(metric_item)
 
     html[:data] ||= {}
-    html[:data].merge!('metric-item-identifier' => identifier, 'metric-item-description' => item.description.try(:strip), 'metric-item-guidance' => guidance)
+    html[:data].merge!('metric-item-identifier' => metric_item.identifier, 'metric-item-description' => item.description.try(:strip), 'metric-item-guidance' => guidance)
 
     html[:class] = Array.wrap(html[:class])
     html[:class] << 'sampled' if sampled
 
-    if guidance?(identifier)
+    if guidance?(metric_item)
       content += content_tag(:span, class: 'm-metric-guidance-toggle') do
         content_tag(:a, '+', href: '#', class: 'a-metric-guidance-expand', data: { behaviour: 'a-metric-guidance-toggle' })
       end
@@ -26,12 +26,12 @@ module MetricItemHelper
     content_tag(:li, row, html)
   end
 
-  def guidance?(identifier)
-    identifier.in?([CallsReceived, TransactionsEndingInOutcome, TransactionsReceived])
+  def guidance?(metric_item)
+    metric_item.in? %w[Metrics::Items::CallsReceived Metrics::Items::TransactionsEndingInOutcome Metrics::Items::TransactionsReceived]
   end
 
 
-  class MetricItem < ActionView::Base
+  class MetricItemContent < ActionView::Base
     include GovernmentServiceDataAPI::MetricStatus
     include MetricFormatterHelper
 

--- a/app/models/metrics.rb
+++ b/app/models/metrics.rb
@@ -7,95 +7,57 @@ module Metrics
   end
 
   module Items
-    TransactionsReceived = 'transactions-received'.freeze
-    TransactionsReceivedOnline = 'transactions-received-online'.freeze
-    TransactionsReceivedPhone = 'transactions-received-phone'.freeze
-    TransactionsReceivedPaper = 'transactions-received-paper'.freeze
-    TransactionsReceivedFaceToFace = 'transactions-received-face-to-face'.freeze
-    TransactionsReceivedOther = 'transactions-received-other'.freeze
-
-    TransactionsEndingInOutcome = 'transactions-ending-in-outcome'.freeze
-    TransactionsEndingInOutcomeWithIntendedOutcome = 'transactions-ending-in-outcome-with-intended-outcome'.freeze
-
-    CallsReceived = 'calls-received'.freeze
-    CallsReceivedPerformTransaction = 'calls-received-perform-transaction'.freeze
-    CallsReceivedGetInformation = 'calls-received-get-information'.freeze
-    CallsReceivedChaseProgress = 'calls-received-chase-progress'.freeze
-    CallsReceivedChallengeADecision = 'calls-received-challenge-a-decision'.freeze
-    CallsReceivedOther = 'calls-received-other'.freeze
-  end
-
-  module OrderBy
-    class Sorter
-      def initialize(identifier, name:, keypath:)
+    class MetricSortAttribute
+      def initialize(identifier, name:, keypath:, index:)
         @identifier = identifier
         @name = name
         @keypath = keypath
+        @index = index
       end
 
-      attr_reader :identifier, :name
+      attr_reader :identifier, :name, :index
 
-      def to_proc
-        ->(metric_group) { @keypath.reduce(metric_group, :send) }
+      def value(metric_group)
+        @keypath.reduce(metric_group, :send)
       end
-    end
 
-    class MetricSorter < Sorter
-      include GovernmentServiceDataAPI::MetricStatus
-
-      def to_proc
-        ->(metric_group) do
-          value = super.(metric_group)
-          if value.in? [NOT_PROVIDED, NOT_APPLICABLE]
-            0
-          else
-            value
-          end
-        end
+      def ==(other)
+        self.identifier == other.identifier
       end
     end
 
-    Name = Sorter.new('name', name: 'name', keypath: [:name])
-    TransactionsReceived = MetricSorter.new(Items::TransactionsReceived, name: 'transactions received', keypath: [:transactions_received, :total])
-    TransactionsReceivedOnline = MetricSorter.new(Items::TransactionsReceivedOnline, name: 'transactions received (online)', keypath: [:transactions_received, :online])
-    TransactionsReceivedPhone = MetricSorter.new(Items::TransactionsReceivedPhone, name: 'transactions received (phone)', keypath: [:transactions_received, :phone])
-    TransactionsReceivedPaper = MetricSorter.new(Items::TransactionsReceivedPaper, name: 'transactions received (paper)', keypath: [:transactions_received, :paper])
-    TransactionsReceivedFaceToFace = MetricSorter.new(Items::TransactionsReceivedFaceToFace, name: 'transactions received (face to face)', keypath: [:transactions_received, :face_to_face])
-    TransactionsReceivedOther = MetricSorter.new(Items::TransactionsReceivedOther, name: 'transactions received (other)', keypath: [:transactions_received, :other])
+    Name = MetricSortAttribute.new('name', name: 'name', keypath: [:entity, :name], index: 0)
 
-    TransactionsEndingInOutcome = MetricSorter.new(Items::TransactionsEndingInOutcome, name: 'transactions processed', keypath: [:transactions_with_outcome, :count])
-    TransactionsEndingInOutcomeWithIntendedOutcome = MetricSorter.new(Items::TransactionsEndingInOutcomeWithIntendedOutcome,
+    TransactionsReceived = MetricSortAttribute.new('transactions-received', name: 'transactions received', keypath: [:transactions_received, :total], index: 1)
+    TransactionsReceivedOnline = MetricSortAttribute.new('transactions-received-online', name: 'transactions received (online)', keypath: [:transactions_received, :online], index: 2)
+    TransactionsReceivedPhone = MetricSortAttribute.new('transactions-received-phone', name: 'transactions received (phone)', keypath: [:transactions_received, :phone], index: 3)
+    TransactionsReceivedPaper = MetricSortAttribute.new('transactions-received-paper', name: 'transactions received (paper)', keypath: [:transactions_received, :paper], index: 4)
+    TransactionsReceivedFaceToFace = MetricSortAttribute.new('transactions-received-face-to-face', name: 'transactions received (face to face)', keypath: [:transactions_received, :face_to_face], index: 5)
+    TransactionsReceivedOther = MetricSortAttribute.new('transactions-received-other', name: 'transactions received (other)', keypath: [:transactions_received, :other], index: 6)
+
+    TransactionsEndingInOutcome = MetricSortAttribute.new('transactions-ending-in-outcome', name: 'transactions processed', keypath: [:transactions_with_outcome, :count], index: 7)
+    TransactionsEndingInOutcomeWithIntendedOutcome = MetricSortAttribute.new('transactions-ending-in-outcome-with-intended-outcome',
       name: "transactions ending in the user's intended outcome",
-      keypath: [:transactions_with_outcome, :count_with_intended_outcome])
+      keypath: [:transactions_with_outcome, :count_with_intended_outcome],
+      index: 8)
 
-    CallsReceived = MetricSorter.new(Items::CallsReceived, name: 'calls received', keypath: [:calls_received, :total])
-    CallsReceivedPerformTransaction = MetricSorter.new(Items::CallsReceivedPerformTransaction, name: 'calls received (perform transaction)', keypath: [:calls_received, :perform_transaction])
-    CallsReceivedGetInformation = MetricSorter.new(Items::CallsReceivedGetInformation, name: 'calls received (get information)', keypath: [:calls_received, :get_information])
-    CallsReceivedChaseProgress = MetricSorter.new(Items::CallsReceivedChaseProgress, name: 'calls received (chase progress)', keypath: [:calls_received, :chase_progress])
-    CallsReceivedChallengeADecision = MetricSorter.new(Items::CallsReceivedChallengeADecision, name: 'calls received (challenge a decision)', keypath: [:calls_received, :challenge_a_decision])
-    CallsReceivedOther = MetricSorter.new(Items::CallsReceivedOther, name: 'calls received (other)', keypath: [:calls_received, :other])
+    CallsReceived = MetricSortAttribute.new('calls-received', name: 'calls received', keypath: [:calls_received, :total], index: 9)
+    CallsReceivedPerformTransaction = MetricSortAttribute.new('calls-received-perform-transaction', name: 'calls received (perform transaction)', keypath: [:calls_received, :perform_transaction], index: 10)
+    CallsReceivedGetInformation = MetricSortAttribute.new('calls-received-get-information', name: 'calls received (get information)', keypath: [:calls_received, :get_information], index: 11)
+    CallsReceivedChaseProgress = MetricSortAttribute.new('calls-received-chase-progress', name: 'calls received (chase progress)', keypath: [:calls_received, :chase_progress], index: 12)
+    CallsReceivedChallengeADecision = MetricSortAttribute.new('calls-received-challenge-a-decision', name: 'calls received (challenge a decision)', keypath: [:calls_received, :challenge_a_decision], index: 13)
+    CallsReceivedOther = MetricSortAttribute.new('calls-received-other', name: 'calls received (other)', keypath: [:calls_received, :other], index: 14)
 
-    ALL = [
-      Name,
-      TransactionsReceived,
-      TransactionsReceivedOnline,
-      TransactionsReceivedPhone,
-      TransactionsReceivedPaper,
-      TransactionsReceivedFaceToFace,
-      TransactionsReceivedOther,
-      TransactionsEndingInOutcome,
-      TransactionsEndingInOutcomeWithIntendedOutcome,
-      CallsReceived,
-      CallsReceivedPerformTransaction,
-      CallsReceivedGetInformation,
-      CallsReceivedChaseProgress,
-      CallsReceivedChallengeADecision,
-      CallsReceivedOther,
-    ].freeze
-
-    def self.fetch(identifier)
-      ALL.index_by(&:identifier).fetch(identifier)
+    def get_metric_sort_attribute(identifier)
+      get_all_metric_sort_attributes.select { |obj| obj.identifier == identifier }.first || Name
     end
+
+    def get_all_metric_sort_attributes
+      ObjectSpace.each_object(MetricSortAttribute).sort_by(&:index)
+    end
+
+
+    module_function :get_metric_sort_attribute, :get_all_metric_sort_attributes
   end
 
   module Order

--- a/app/models/metrics.rb
+++ b/app/models/metrics.rb
@@ -8,11 +8,27 @@ module Metrics
 
   module Items
     class MetricSortAttribute
+      @attributes = {}
+
+      def self.add(identifier, obj)
+        @attributes[identifier] = obj
+      end
+
+      def self.get(identifier)
+        @attributes.fetch(identifier, nil)
+      end
+
+      def self.all
+        @attributes.values.sort_by(&:index)
+      end
+
       def initialize(identifier, name:, keypath:, index:)
         @identifier = identifier
         @name = name
         @keypath = keypath
         @index = index
+
+        self.class.add(identifier, self)
       end
 
       attr_reader :identifier, :name, :index
@@ -49,15 +65,10 @@ module Metrics
     CallsReceivedOther = MetricSortAttribute.new('calls-received-other', name: 'calls received (other)', keypath: [:calls_received, :other], index: 14)
 
     def get_metric_sort_attribute(identifier)
-      get_all_metric_sort_attributes.detect { |obj| obj.identifier == identifier } || Name
+      MetricSortAttribute.get(identifier) || Name
     end
 
-    def get_all_metric_sort_attributes
-      ObjectSpace.each_object(MetricSortAttribute).sort_by(&:index)
-    end
-
-
-    module_function :get_metric_sort_attribute, :get_all_metric_sort_attributes
+    module_function :get_metric_sort_attribute
   end
 
   module Order

--- a/app/models/metrics.rb
+++ b/app/models/metrics.rb
@@ -49,7 +49,7 @@ module Metrics
     CallsReceivedOther = MetricSortAttribute.new('calls-received-other', name: 'calls received (other)', keypath: [:calls_received, :other], index: 14)
 
     def get_metric_sort_attribute(identifier)
-      get_all_metric_sort_attributes.select { |obj| obj.identifier == identifier }.first || Name
+      get_all_metric_sort_attributes.detect { |obj| obj.identifier == identifier } || Name
     end
 
     def get_all_metric_sort_attributes

--- a/app/presenters/metric_group_presenter.rb
+++ b/app/presenters/metric_group_presenter.rb
@@ -33,9 +33,10 @@ class MetricGroupPresenter
     end
   end
 
-  def initialize(metric_group, collapsed: false)
+  def initialize(metric_group, collapsed: false, sort_value: nil)
     @metric_group = metric_group
     @collapsed = collapsed
+    @sort_value = sort_value
   end
 
   def entity
@@ -48,6 +49,8 @@ class MetricGroupPresenter
 
   delegate :name, to: :entity
   delegate :transactions_received, :transactions_with_outcome, :calls_received, to: :@metric_group
+
+  attr_reader :sort_value
 
   def completeness
     res = @metric_group.metrics.reduce([0, 0]) { |memo, hash|
@@ -78,6 +81,10 @@ class MetricGroupPresenter
     if entity.respond_to?(:services_count)
       entity.services_count
     end
+  end
+
+  def has_sort_value?
+    !@sort_value.in? [:not_provided, :not_applicable]
   end
 
   def collapsed?

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -37,7 +37,7 @@
         <%= form_for @metrics, as: :filter, url: '', method: 'get', class: 'filter-row' do |f| %>
           <div class="m-sort-filter">
             <%= f.label :order_by, 'Sort by' %>
-            <%= f.select :order_by, Metrics::Items.get_all_metric_sort_attributes.map {|order| [order.name, order.identifier]}, {}, class: 'form-control' %>
+            <%= f.select :order_by, Metrics::Items::MetricSortAttribute.all.map {|order| [order.name, order.identifier]}, {}, class: 'form-control' %>
 
             <div class="m-sort-order">
               <label><%= f.radio_button :order, Metrics::Order::Descending %> <span><%= @metrics.high_to_low_label %></span></label>

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -37,7 +37,7 @@
         <%= form_for @metrics, as: :filter, url: '', method: 'get', class: 'filter-row' do |f| %>
           <div class="m-sort-filter">
             <%= f.label :order_by, 'Sort by' %>
-            <%= f.select :order_by, Metrics::OrderBy::ALL.map {|order| [order.name, order.identifier]}, {}, class: 'form-control' %>
+            <%= f.select :order_by, Metrics::Items.get_all_metric_sort_attributes.map {|order| [order.name, order.identifier]}, {}, class: 'form-control' %>
 
             <div class="m-sort-order">
               <label><%= f.radio_button :order, Metrics::Order::Descending %> <span><%= @metrics.high_to_low_label %></span></label>

--- a/spec/features/viewing_metrics_spec.rb
+++ b/spec/features/viewing_metrics_spec.rb
@@ -31,8 +31,6 @@ RSpec.feature 'viewing metrics', type: :feature do
           ['Department of Health', '18132669'],
           ['Department for Education', '13000475'],
           ['Department for Environment Food & Rural Affairs', '3000039'],
-          ['Department for Business, Energy & Industrial Strategy', nil],
-          ['HM Revenue & Customs', nil],
         ])
 
         if javascript_enabled
@@ -45,8 +43,6 @@ RSpec.feature 'viewing metrics', type: :feature do
         all('a', text: /\AOpen\z/).each(&:click) if javascript_enabled
 
         expect(metric_groups(:name, :transactions_received_total)).to eq([
-          ['HM Revenue & Customs', nil],
-          ['Department for Business, Energy & Industrial Strategy', nil],
           ['Department for Environment Food & Rural Affairs', '3000039'],
           ['Department for Education', '13000475'],
           ['Department of Health', '18132669'],
@@ -58,14 +54,14 @@ RSpec.feature 'viewing metrics', type: :feature do
     end
 
     it 'collapses metric groups, when sorting by attributes (other than name)', cassette: 'viewing-metrics-collapsing-metric-groups', js: true do
-      visit government_metrics_path(group_by: Metrics::Group::Department)
+      visit government_metrics_path(group_by: Metrics::Group::Department, order_by: "name")
 
       expect(page).to have_selector('.m-metric-group', count: 8)
       expect(page).to have_selector('.m-metric-group[data-behaviour~="m-metric-group__collapsible"]', count: 0)
       expect(page).to have_selector('.completeness', count: 8)
 
       select 'transactions received', from: 'Sort by'
-      expect(page).to have_selector('.m-metric-group[data-behaviour~="m-metric-group__collapsible"]', count: 8)
+      expect(page).to have_selector('.m-metric-group[data-behaviour~="m-metric-group__collapsible"]', count: 6)
     end
   end
 
@@ -74,7 +70,7 @@ RSpec.feature 'viewing metrics', type: :feature do
   def metric_groups(*attrs)
     attributes = ->(metric_group) { attrs.map { |attribute| metric_group.send(attribute) } }
 
-    all('.m-metric-group', count: 8)
+    all('.m-metric-group')
       .map { |element| MetricGroup.new(element) }
       .collect(&attributes)
   end

--- a/spec/helpers/metric_item_helper_spec.rb
+++ b/spec/helpers/metric_item_helper_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe MetricItemHelper, type: :helper do
   describe '#metric_item' do
-    let(:identifier) { Metrics::Items::TransactionsReceived }
+    let(:metric_sort_attribute) { Metrics::Items::TransactionsReceived }
 
     it 'wraps the content in an <li>' do
-      output = metric_item(identifier, 0) do
+      output = metric_item(metric_sort_attribute, 0) do
         "<p>Content</p>".html_safe
       end
 
@@ -13,17 +13,17 @@ RSpec.describe MetricItemHelper, type: :helper do
     end
 
     it 'passes html options to the content tag' do
-      output = metric_item(identifier, 0, html: { class: 'optional-class' }) {}
+      output = metric_item(metric_sort_attribute, 0, html: { class: 'optional-class' }) {}
       expect(output).to have_selector('li.optional-class')
     end
 
     it 'includes the identifier as a data attribute' do
-      output = metric_item(identifier, 0) {}
+      output = metric_item(metric_sort_attribute, 0) {}
       expect(output).to have_selector('li[data-metric-item-identifier="transactions-received"]')
     end
 
     it 'includes the description as a data attribute' do
-      output = metric_item(identifier, 0) do |item|
+      output = metric_item(metric_sort_attribute, 0) do |item|
         item.description do
           '<strong>transactions-received</strong> description'
         end
@@ -34,7 +34,7 @@ RSpec.describe MetricItemHelper, type: :helper do
     end
 
     it 'adds a sampled class, if sampled' do
-      output = metric_item(identifier, 0, sampled: true) {}
+      output = metric_item(metric_sort_attribute, 0, sampled: true) {}
       expect(output).to have_selector('li.sampled')
     end
   end

--- a/spec/helpers/metric_item_helper_spec.rb
+++ b/spec/helpers/metric_item_helper_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe MetricItemHelper, type: :helper do
   describe '#metric_item' do
-    let(:identifier) { 'transactions-received' }
+    let(:identifier) { Metrics::Items::TransactionsReceived }
 
     it 'wraps the content in an <li>' do
       output = metric_item(identifier, 0) do


### PR DESCRIPTION
When sorting by metric item (for instance, transactions received total)
and showing the collapsed services, we previously showed items that had
no value (or description in the collapsed view).  This PR hides those
items from the list, making the sort act as a sort and filter.

This PR does not change the number of things being shown (total in tab
text) and therefore can look a little strange when it suggest 34
services but only 7 are showing.