### PR TITLE
Content changes

### DIFF
--- a/app/assets/javascripts/collapsed_metric_group.js
+++ b/app/assets/javascripts/collapsed_metric_group.js
@@ -12,7 +12,6 @@
     $(this).each(function (idx, element) {
       var metricItem = $(element).find('[data-metric-item-identifier="' + selectedMetricItem + '"]')
       var metricItemDescription = metricItem.data('metric-item-description')
-
       var metricGroup = $(element)
       var collapsedHeaderContainer = $('<div />', { 'class': 'm-metric-group-header' })
       var metricItemDescriptionContainer = $('<div />', { 'class': 'm-metric-item-description' })

--- a/app/assets/stylesheets/_metric_group.scss
+++ b/app/assets/stylesheets/_metric_group.scss
@@ -119,6 +119,11 @@
   border: 1px solid #BFC1C3;
   margin-top: -1px;
   margin-bottom: 0;
+  .total-heading:after {
+    content: attr(subheading);
+    padding-left: 4px;
+    font-weight: normal;
+  }
 }
 
 .m-metric-group-close-toggle {

--- a/app/presenters/metrics_presenter.rb
+++ b/app/presenters/metrics_presenter.rb
@@ -97,7 +97,7 @@ class MetricsPresenter
   end
 
   def visible_services_count
-    metric_groups.drop(1).sum { |m|
+    metric_groups.without(totals_metric_group_presenter).sum { |m|
       if m.entity.respond_to? :services_count
         m.entity.services_count
       else

--- a/app/presenters/metrics_presenter.rb
+++ b/app/presenters/metrics_presenter.rb
@@ -96,6 +96,16 @@ class MetricsPresenter
     end
   end
 
+  def visible_services_count
+    metric_groups.drop(1).sum { |m|
+      if m.entity.respond_to? :services_count
+        m.entity.services_count
+      else
+        1
+      end
+    }
+  end
+
   def services_count
     if has_services?
       entity.services_count

--- a/app/views/metric_groups/header/_total.html.erb
+++ b/app/views/metric_groups/header/_total.html.erb
@@ -1,3 +1,5 @@
+<% service_count = @metrics.visible_services_count %>
 <div class="m-metric-group-header">
-  <h2 class="bold-medium">Total for <%= metric_group.name %></h2>
+  <h2 class="total-heading bold-medium" subheading='based on <%= service_count %> <%= "service".pluralize(service_count) %>' >Total for <%= metric_group.name %></h2>
+  <span class="total-subheading">based on <%= service_count %> <%= "service".pluralize(service_count) %></span>
 </div>

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -36,7 +36,7 @@
       <div class="o-filter-panel" data-behaviour="o-filter-panel">
         <%= form_for @metrics, as: :filter, url: '', method: 'get', class: 'filter-row' do |f| %>
           <div class="m-sort-filter">
-            <%= f.label :order_by, 'Sort by' %>
+            <%= f.label :order_by, 'Sort by metric' %>
             <%= f.select :order_by, Metrics::Items::MetricSortAttribute.all.map {|order| [order.name, order.identifier]}, {}, class: 'form-control' %>
 
             <div class="m-sort-order">
@@ -64,7 +64,6 @@
           <% @metrics.metric_groups.each do |metric_group|  %>
             <li class="m-metric-group<% if metric_group.totals? %> m-metric-group__totals<% end %><% if metric_group.collapsed? %> m-metric-group__collapsed<% else %> m-metric-group__expanded<% end %>" data-behaviour="m-metric-group<% if metric_group.collapsed? %> m-metric-group__collapsible<% end %>">
               <div data-metric-group-expanded>
-
                 <%= render "metrics/completeness", metric_group: metric_group %>
                 <%= render metric_group.entity, metric_group: metric_group  %>
 

--- a/app/views/pages/how_to_use.html.erb
+++ b/app/views/pages/how_to_use.html.erb
@@ -13,7 +13,7 @@
       <h1 class="heading-large">
         What is Service Performance?
       </h1>
-      <p>Service Performance is a platform that displays performance data from transactional, public-facing services across government.</p>
+      <p>Service Performance is a product that displays performance data from transactional, public-facing services across government.</p>
         <h1 class="heading-large">
           Who is it for?
       </h1>
@@ -35,7 +35,7 @@
         How does it work?
       </h1>
 
-        <p>Each service publishes monthly data to the platform, according to an agreed set of metrics. This data is displayed as a 12-month aggregation on a page dedicated to that particular service, alongside contextual information about the service and its users. You can access the page to find out more about the service and how it's performing.</p>
+        <p>Each service publishes monthly data to the tool, according to an agreed set of metrics. This data is displayed as a 12-month aggregation on a page dedicated to that particular service, alongside contextual information about the service and its users. You can access the page to find out more about the service and how it's performing.</p>
 
         <p>You can also group services by government, delivery organisation or department, and sort by each metric to produce a ranking comparison of services.</p>
 

--- a/spec/features/viewing_metrics_spec.rb
+++ b/spec/features/viewing_metrics_spec.rb
@@ -63,6 +63,16 @@ RSpec.feature 'viewing metrics', type: :feature do
       select 'transactions received', from: 'Sort by'
       expect(page).to have_selector('.m-metric-group[data-behaviour~="m-metric-group__collapsible"]', count: 6)
     end
+
+    it 'gov totals show how many services', cassette: 'viewing-metrics-collapsing-metric-groups', js: true do
+      visit government_metrics_path(group_by: Metrics::Group::Department, order_by: "name")
+      expect(page).to have_content('based on 31 services', count: 1)
+    end
+
+    it 'collapsed totals show how many services', cassette: 'viewing-metrics-collapsing-metric-groups', js: true do
+      visit government_metrics_path(group_by: Metrics::Group::Department, order_by: "transactions-received")
+      expect(page).to have_content('based on 31 services', count: 1)
+    end
   end
 
   private


### PR DESCRIPTION
The first two commits are simple content changes.

The last is also a content change, but requires code to determine what the content should be.  This is adding 'based on X services' where X is determined by the services_count of the shown items.  When we collapse the groups this means X will be calculated from what is shown, not what was returned from the API.